### PR TITLE
feat: Add Integration Management Tools (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ Hass-MCP provides several tools for interacting with Home Assistant:
 - `get_error_log`: Get the Home Assistant error log
 - `system_health`: Get system health information for all components
 - `core_config`: Get core configuration (location, timezone, unit system, components)
+- `list_integrations`: Get a list of all configuration entries (integrations) with optional domain filtering
+- `get_integration_config`: Get detailed configuration for a specific integration entry
+- `reload_integration`: Reload a specific integration (use with caution)
 
 ## Prompts for Guided Conversations
 


### PR DESCRIPTION
## Overview
This PR implements integration management tools as requested in issue #2. It adds three new MCP tools for listing, inspecting, and managing Home Assistant integrations (configuration entries).

## Changes Made

### API Implementation (app/hass.py)
- ✅ Added get_integrations(domain=None) - List all configuration entries with optional domain filtering
- ✅ Added get_integration_config(entry_id) - Get detailed configuration for a specific integration entry
- ✅ Added reload_integration(entry_id) - Reload a specific integration

### MCP Tools (app/server.py)
- ✅ Added list_integrations tool - List all integrations with optional domain filtering
- ✅ Added get_integration_config tool - Get detailed config for specific integration
- ✅ Added reload_integration tool - Reload a specific integration (use with caution)

### Documentation
- ✅ Updated README.md with new tools and usage examples
- ✅ Added comprehensive docstrings with examples and best practices

## Features

### 1. List Integrations
- List all configuration entries (integrations)
- Optional domain filtering (e.g., filter by 'mqtt', 'zwave')
- Returns entry_id, domain, title, source, state, and preferences
- Helps identify integrations with errors by checking state field

### 2. Get Integration Config
- Get detailed configuration for a specific integration entry
- Returns full configuration including options
- Useful for debugging integration configuration issues
- Proper error handling for missing entries (404)

### 3. Reload Integration
- Reload a specific integration
- May cause temporary unavailability (use with caution)
- Useful for troubleshooting integration setup errors
- Proper error handling and warnings

## Error Handling
- All functions use @handle_api_errors decorator
- Returns error dicts for missing entries (404)
- Clear error messages for troubleshooting

## Testing
- Code passes all linting checks
- All imports properly configured
- Pre-commit hooks passing

Closes #2