### PR TITLE
feat: Add Devices Management Tools (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,10 @@ Hass-MCP provides several tools for interacting with Home Assistant:
 - `update_area`: Update an existing area (name, aliases, picture)
 - `delete_area`: Delete an area (permanent, removes area_id from entities)
 - `get_area_summary`: Get summary of all areas with entity distribution
+- `list_devices`: Get a list of all devices, optionally filtered by integration domain
+- `get_device`: Get detailed device information
+- `get_device_entities`: Get all entities belonging to a specific device
+- `get_device_stats`: Get statistics about devices (by manufacturer, model, integration)
 - `call_service_tool`: Call any Home Assistant service
 - `restart_ha`: Restart Home Assistant
 - `system_overview`: Get a comprehensive overview of the entire Home Assistant system

--- a/app/hass.py
+++ b/app/hass.py
@@ -1215,6 +1215,203 @@ async def get_area_summary() -> dict[str, Any]:
 
 
 @handle_api_errors
+async def get_devices(domain: str | None = None) -> list[dict[str, Any]]:
+    """
+    Get list of all devices, optionally filtered by integration domain
+
+    Args:
+        domain: Optional integration domain to filter devices by (e.g., 'hue', 'zwave')
+
+    Returns:
+        List of device dictionaries containing:
+        - id: Unique device identifier
+        - name: Device name
+        - manufacturer: Manufacturer name
+        - model: Model name
+        - via_device_id: Parent device ID if device is connected via another device
+        - area_id: Area ID the device belongs to
+        - name_by_user: User-defined name (if set)
+        - disabled_by: Reason device is disabled (if disabled)
+        - entities: List of entity IDs belonging to this device
+        - identifiers: List of identifier tuples (e.g., [["domain", "unique_id"]])
+        - connections: List of connection tuples (e.g., [["mac", "aa:bb:cc:dd:ee:ff"]])
+
+    Example response:
+        [
+            {
+                "id": "device_id",
+                "name": "Device Name",
+                "manufacturer": "Manufacturer",
+                "model": "Model Name",
+                "via_device_id": null,
+                "area_id": "living_room",
+                "entities": ["entity_id_1", "entity_id_2"],
+                "identifiers": [["domain", "unique_id"]],
+                "connections": [["mac", "aa:bb:cc:dd:ee:ff"]]
+            }
+        ]
+
+    Note:
+        Devices represent physical hardware units.
+        Filtering by domain matches the first identifier's domain.
+    """
+    client = await get_client()
+    response = await client.get(
+        f"{HA_URL}/api/config/devices",
+        headers=get_ha_headers(),
+    )
+    response.raise_for_status()
+    devices = response.json()
+
+    # Filter by domain if specified
+    if domain:
+        filtered_devices = []
+        for device in devices:
+            identifiers = device.get("identifiers", [])
+            if identifiers and len(identifiers) > 0:
+                # First identifier contains [domain, unique_id]
+                device_domain = identifiers[0][0] if len(identifiers[0]) > 0 else None
+                if device_domain == domain:
+                    filtered_devices.append(device)
+        devices = filtered_devices
+
+    return devices
+
+
+@handle_api_errors
+async def get_device_details(device_id: str) -> dict[str, Any]:
+    """
+    Get detailed device information
+
+    Args:
+        device_id: The device ID to get details for
+
+    Returns:
+        Detailed device dictionary with:
+        - id: Unique device identifier
+        - name: Device name
+        - manufacturer: Manufacturer name
+        - model: Model name
+        - via_device_id: Parent device ID if device is connected via another device
+        - area_id: Area ID the device belongs to
+        - name_by_user: User-defined name (if set)
+        - disabled_by: Reason device is disabled (if disabled)
+        - entities: List of entity IDs belonging to this device
+        - identifiers: List of identifier tuples
+        - connections: List of connection tuples (MAC addresses, etc.)
+
+    Note:
+        This provides the same information as get_devices but for a single device.
+        Useful when you already know the device_id.
+    """
+    client = await get_client()
+    response = await client.get(
+        f"{HA_URL}/api/config/devices/{device_id}",
+        headers=get_ha_headers(),
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+@handle_api_errors
+async def get_device_entities(device_id: str) -> list[dict[str, Any]]:
+    """
+    Get all entities belonging to a specific device
+
+    Args:
+        device_id: The device ID to get entities for
+
+    Returns:
+        List of entity dictionaries belonging to the device
+
+    Note:
+        Entities are retrieved from the device's entity list.
+        Returns empty list if device has no entities or device doesn't exist.
+    """
+    device = await get_device_details(device_id)
+
+    entity_ids = device.get("entities", [])
+    entities = []
+    for entity_id in entity_ids:
+        entity = await get_entity_state(entity_id, lean=True)
+        entities.append(entity)
+
+    return entities
+
+
+@handle_api_errors
+async def get_device_statistics() -> dict[str, Any]:
+    """
+    Get statistics about devices (counts by manufacturer, model, etc.)
+
+    Returns:
+        Dictionary containing:
+        - total_devices: Total number of devices
+        - by_manufacturer: Dictionary mapping manufacturer to count
+        - by_model: Dictionary mapping model to count
+        - by_integration: Dictionary mapping integration domain to count
+        - disabled_devices: Number of disabled devices
+
+    Example response:
+        {
+            "total_devices": 25,
+            "by_manufacturer": {
+                "Philips": 5,
+                "Samsung": 3,
+                "Unknown": 2
+            },
+            "by_model": {
+                "Hue Bridge": 2,
+                "Smart TV": 1
+            },
+            "by_integration": {
+                "hue": 5,
+                "zwave": 10,
+                "mqtt": 5
+            },
+            "disabled_devices": 1
+        }
+
+    Best Practices:
+        - Use this to understand device distribution
+        - Identify common manufacturers and models
+        - See which integrations have the most devices
+        - Track disabled devices
+    """
+    devices = await get_devices()
+
+    stats: dict[str, Any] = {
+        "total_devices": len(devices),
+        "by_manufacturer": {},
+        "by_model": {},
+        "by_integration": {},
+        "disabled_devices": 0,
+    }
+
+    for device in devices:
+        manufacturer = device.get("manufacturer") or "Unknown"
+        model = device.get("model") or "Unknown"
+
+        # Count by manufacturer
+        stats["by_manufacturer"][manufacturer] = stats["by_manufacturer"].get(manufacturer, 0) + 1
+
+        # Count by model
+        stats["by_model"][model] = stats["by_model"].get(model, 0) + 1
+
+        # Count by integration
+        identifiers = device.get("identifiers", [])
+        if identifiers and len(identifiers) > 0:
+            integration = identifiers[0][0] if len(identifiers[0]) > 0 else "Unknown"
+            stats["by_integration"][integration] = stats["by_integration"].get(integration, 0) + 1
+
+        # Count disabled
+        if device.get("disabled_by"):
+            stats["disabled_devices"] += 1
+
+    return stats
+
+
+@handle_api_errors
 async def get_integrations(domain: str | None = None) -> list[dict[str, Any]]:
     """
     Get list of all configuration entries (integrations)

--- a/app/server.py
+++ b/app/server.py
@@ -26,6 +26,10 @@ from app.hass import (
     get_automation_execution_log,
     get_automations,
     get_core_config,
+    get_device_details,
+    get_device_entities,
+    get_device_statistics,
+    get_devices,
     get_entities,
     get_entity_history,
     get_entity_state,
@@ -1574,6 +1578,134 @@ async def get_area_summary_tool() -> dict[str, Any]:
     """
     logger.info("Getting area summary")
     return await get_area_summary()
+
+
+@mcp.tool()
+@async_handler("list_devices")
+async def list_devices_tool(domain: str | None = None) -> list[dict[str, Any]]:
+    """
+    Get a list of all devices in Home Assistant, optionally filtered by integration domain
+
+    Args:
+        domain: Optional integration domain to filter devices by (e.g., 'hue', 'zwave')
+
+    Returns:
+        List of device dictionaries containing:
+        - id: Unique device identifier
+        - name: Device name
+        - manufacturer: Manufacturer name
+        - model: Model name
+        - via_device_id: Parent device ID if device is connected via another device
+        - area_id: Area ID the device belongs to
+        - entities: List of entity IDs belonging to this device
+        - identifiers: List of identifier tuples
+        - connections: List of connection tuples (MAC addresses, etc.)
+
+    Examples:
+        domain=None - get all devices
+        domain="hue" - get all Philips Hue devices
+
+    Best Practices:
+        - Use this to discover available devices
+        - Filter by domain to find devices from specific integrations
+        - Check device identifiers to understand device topology
+    """
+    logger.info("Getting list of devices" + (f" for domain: {domain}" if domain else ""))
+    return await get_devices(domain)
+
+
+@mcp.tool()
+@async_handler("get_device")
+async def get_device_tool(device_id: str) -> dict[str, Any]:
+    """
+    Get detailed device information
+
+    Args:
+        device_id: The device ID to get details for
+
+    Returns:
+        Detailed device dictionary with:
+        - id: Unique device identifier
+        - name: Device name
+        - manufacturer: Manufacturer name
+        - model: Model name
+        - via_device_id: Parent device ID if device is connected via another device
+        - area_id: Area ID the device belongs to
+        - name_by_user: User-defined name (if set)
+        - disabled_by: Reason device is disabled (if disabled)
+        - entities: List of entity IDs belonging to this device
+        - identifiers: List of identifier tuples
+        - connections: List of connection tuples (MAC addresses, etc.)
+
+    Examples:
+        device_id="abc123" - get details for device with ID abc123
+
+    Note:
+        This provides the same information as list_devices but for a single device.
+        Useful when you already know the device_id.
+
+    Best Practices:
+        - Use this to inspect device details
+        - Check manufacturer and model for device identification
+        - Review connections to understand device topology
+    """
+    logger.info(f"Getting device details for: {device_id}")
+    return await get_device_details(device_id)
+
+
+@mcp.tool()
+@async_handler("get_device_entities")
+async def get_device_entities_tool(device_id: str) -> list[dict[str, Any]]:
+    """
+    Get all entities belonging to a specific device
+
+    Args:
+        device_id: The device ID to get entities for
+
+    Returns:
+        List of entity dictionaries belonging to the device
+
+    Examples:
+        device_id="abc123" - get all entities for device with ID abc123
+
+    Note:
+        Entities are retrieved from the device's entity list.
+        Returns empty list if device has no entities or device doesn't exist.
+
+    Best Practices:
+        - Use this to understand what a device controls
+        - Check entities to see device capabilities
+        - Use before removing or disabling a device
+    """
+    logger.info(f"Getting entities for device: {device_id}")
+    return await get_device_entities(device_id)
+
+
+@mcp.tool()
+@async_handler("get_device_stats")
+async def get_device_stats_tool() -> dict[str, Any]:
+    """
+    Get statistics about devices (counts by manufacturer, model, etc.)
+
+    Returns:
+        Dictionary containing:
+        - total_devices: Total number of devices
+        - by_manufacturer: Dictionary mapping manufacturer to count
+        - by_model: Dictionary mapping model to count
+        - by_integration: Dictionary mapping integration domain to count
+        - disabled_devices: Number of disabled devices
+
+    Examples:
+        Returns statistics about all devices in the system
+
+    Best Practices:
+        - Use this to understand device distribution
+        - Identify common manufacturers and models
+        - See which integrations have the most devices
+        - Track disabled devices
+    """
+    logger.info("Getting device statistics")
+    return await get_device_statistics()
 
 
 @mcp.tool()


### PR DESCRIPTION
## Overview
This PR implements device management capabilities as requested in issue #6. It adds tools to list, inspect, and analyze Home Assistant devices, which represent physical hardware units and are essential for understanding system topology and debugging connectivity issues.

## Changes Made

### API Implementation (app/hass.py)
- ✅ Added get_devices(domain) - Get list of all devices, optionally filtered by domain
- ✅ Added get_device_details(device_id) - Get detailed device information
- ✅ Added get_device_entities(device_id) - Get all entities belonging to a device
- ✅ Added get_device_statistics() - Get statistics about devices

### MCP Tools (app/server.py)
- ✅ Added list_devices tool (with optional domain filtering)
- ✅ Added get_device tool
- ✅ Added get_device_entities tool
- ✅ Added get_device_stats tool

### Documentation
- ✅ Updated README.md with new device management tools
- ✅ Added comprehensive docstrings with examples and best practices

## Features

### Device Discovery
- **List Devices**: Get all devices with basic information (manufacturer, model, area, connections)
- **Filter by Domain**: Filter devices by integration domain (e.g., 'hue', 'zwave', 'mqtt')
- **Get Device Details**: Get detailed device information including identifiers, connections, and entity list

### Device Analysis
- **Get Device Entities**: Find all entities belonging to a specific device
- **Device Statistics**: Get statistics about device distribution:
  - Count by manufacturer
  - Count by model
  - Count by integration
  - Disabled devices count

### Topology Understanding
- **Device Hierarchy**: See via_device_id to understand device connections and parent-child relationships
- **Entity Mapping**: Understand which entities belong to which devices
- **Integration Mapping**: See which integrations manage which devices

## Error Handling
- All functions use @handle_api_errors decorator
- Proper error handling for missing devices (404)
- Handle devices without manufacturer/model information gracefully (defaults to "Unknown")
- Clear error messages for invalid operations

## Usage Examples

```python
# List all devices
devices = await get_devices()

# Filter devices by domain
hue_devices = await get_devices(domain="hue")
zwave_devices = await get_devices(domain="zwave")

# Get device details
device = await get_device_details("device_id")

# Get entities for a device
entities = await get_device_entities("device_id")

# Get device statistics
stats = await get_device_statistics()
# Returns: {
#   "total_devices": 25,
#   "by_manufacturer": {"Philips": 5, "Samsung": 3, "Unknown": 2},
#   "by_model": {"Hue Bridge": 2, "Smart TV": 1},
#   "by_integration": {"hue": 5, "zwave": 10, "mqtt": 5},
#   "disabled_devices": 1
# }
```

## Best Practices
- List devices to understand hardware topology
- Filter by domain to find devices from specific integrations
- Get device details to identify manufacturer and model
- Use device statistics to understand system distribution
- Check device entities before removing or disabling devices
- Review via_device_id to understand device hierarchy

## Testing
- Code passes all linting checks
- All imports properly configured
- Pre-commit hooks passing
- Proper error handling for missing devices

Closes #6