### PR TITLE
feat: Add Scenes Management Tools (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,15 @@ Hass-MCP provides several tools for interacting with Home Assistant:
 - `update_area`: Update an existing area (name, aliases, picture)
 - `delete_area`: Delete an area (permanent, removes area_id from entities)
 - `get_area_summary`: Get summary of all areas with entity distribution
+- `list_devices`: Get a list of all devices, optionally filtered by integration domain
+- `get_device`: Get detailed device information
+- `get_device_entities`: Get all entities belonging to a specific device
+- `get_device_stats`: Get statistics about devices (by manufacturer, model, integration)
+- `list_scenes`: Get a list of all scenes in Home Assistant
+- `get_scene`: Get scene configuration (what entities/values it saves)
+- `create_scene`: Create a new scene (may provide YAML example if API unavailable)
+- `activate_scene`: Activate/restore a scene to restore saved states
+- `reload_scenes`: Reload scenes from configuration
 - `call_service_tool`: Call any Home Assistant service
 - `restart_ha`: Restart Home Assistant
 - `system_overview`: Get a comprehensive overview of the entire Home Assistant system


### PR DESCRIPTION
## Overview
This PR implements scene management capabilities as requested in issue #7. It adds tools to list, inspect, create, and activate Home Assistant scenes, which capture the state of multiple entities at a point in time and are essential for creating lighting presets and room configurations.

## Changes Made

### API Implementation (app/hass.py)
- ✅ Added get_scenes() - Get list of all scenes
- ✅ Added get_scene_config(scene_id) - Get scene configuration (what entities/values it saves)
- ✅ Added create_scene(name, entity_ids, states) - Create new scene (with YAML example if API unavailable)
- ✅ Added activate_scene(scene_id) - Activate/restore a scene
- ✅ Added reload_scenes() - Reload scenes from configuration

### MCP Tools (app/server.py)
- ✅ Added list_scenes tool
- ✅ Added get_scene tool
- ✅ Added create_scene tool (with helpful error messages)
- ✅ Added activate_scene tool
- ✅ Added reload_scenes tool

### Documentation
- ✅ Updated README.md with new scene management tools
- ✅ Added comprehensive docstrings with examples and best practices

## Features

### Scene Discovery
- **List Scenes**: Get all scenes with their configuration (name, entities, snapshot)
- **Get Scene Config**: Inspect scene configuration to see what entities it affects

### Scene Management
- **Create Scenes**: Create new scenes via API (with YAML example fallback if API unavailable)
- **Activate Scenes**: Restore saved states by activating scenes
- **Reload Scenes**: Reload scenes after configuration changes

### State Management
- **Entity Snapshots**: View snapshots of entity states when scene was created
- **State Restoration**: Restore entities to their saved states

## Error Handling
- All functions use @handle_api_errors decorator
- Proper error handling for missing scenes (404)
- Graceful handling when scene creation API is unavailable (provides YAML configuration example)
- Clear error messages for invalid operations

## Usage Examples

```python
# List all scenes
scenes = await get_scenes()

# Get scene configuration
config = await get_scene_config("living_room_dim")

# Create scene capturing current states
scene = await create_scene("Living Room Dim", ["light.living_room", "light.kitchen"])

# Create scene with specific states
scene = await create_scene(
    "Movie Mode",
    ["light.living_room"],
    {"light.living_room": {"state": "on", "brightness": 50}}
)

# Activate scene
result = await activate_scene("living_room_dim")

# Reload scenes after config changes
result = await reload_scenes()
```

## Best Practices
- List scenes to discover available presets
- Get scene config to see what entities it affects
- Use activate_scene to restore room configurations
- If scene creation fails, use the provided YAML example for manual creation
- Reload scenes after making configuration changes

## Testing
- Code passes all linting checks
- All imports properly configured
- Pre-commit hooks passing
- Proper error handling for missing scenes
- Graceful handling when scene creation API is unavailable

Closes #7