### PR TITLE
feat: Add Blueprints Management Tools (closes #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,10 @@ Hass-MCP provides several tools for interacting with Home Assistant:
 - `list_integrations`: Get a list of all configuration entries (integrations) with optional domain filtering
 - `get_integration_config`: Get detailed configuration for a specific integration entry
 - `reload_integration`: Reload a specific integration (use with caution)
+- `list_blueprints`: Get a list of all available blueprints, optionally filtered by domain
+- `get_blueprint`: Get blueprint definition and metadata
+- `import_blueprint`: Import blueprint from URL
+- `create_automation_from_blueprint`: Create automation from blueprint with specified inputs
 
 ## Prompts for Guided Conversations
 

--- a/app/hass.py
+++ b/app/hass.py
@@ -3,6 +3,7 @@ import inspect
 import json
 import logging
 import re
+import urllib.parse
 import uuid
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
@@ -2349,3 +2350,186 @@ async def get_core_config() -> dict[str, Any]:
     response = await client.get(f"{HA_URL}/api/config", headers=get_ha_headers())
     response.raise_for_status()
     return response.json()
+
+
+@handle_api_errors
+async def get_blueprints(domain: str | None = None) -> list[dict[str, Any]]:
+    """
+    Get list of available blueprints
+
+    Args:
+        domain: Optional domain to filter blueprints by (e.g., 'automation')
+
+    Returns:
+        List of blueprint dictionaries containing:
+        - path: Blueprint path
+        - domain: Blueprint domain
+        - name: Blueprint name
+        - metadata: Blueprint metadata
+
+    Example response:
+        [
+            {
+                "path": "blueprint_path",
+                "domain": "automation",
+                "name": "Blueprint Name",
+                "metadata": {...}
+            }
+        ]
+
+    Note:
+        Blueprints are reusable automation templates.
+        If domain is provided, returns blueprints for that domain only.
+    """
+    client = await get_client()
+
+    url = f"{HA_URL}/api/blueprint/domain/{domain}" if domain else f"{HA_URL}/api/blueprint/list"
+
+    response = await client.get(url, headers=get_ha_headers())
+    response.raise_for_status()
+    return response.json()
+
+
+@handle_api_errors
+async def get_blueprint_definition(blueprint_id: str, domain: str | None = None) -> dict[str, Any]:
+    """
+    Get blueprint definition and metadata
+
+    Args:
+        blueprint_id: The blueprint ID to get (may include domain and path)
+        domain: Optional domain for the blueprint (e.g., 'automation')
+
+    Returns:
+        Blueprint definition dictionary with:
+        - path: Blueprint path
+        - domain: Blueprint domain
+        - name: Blueprint name
+        - metadata: Blueprint metadata including inputs, description
+        - definition: Blueprint YAML definition
+
+    Example response:
+        {
+            "path": "blueprint_path",
+            "domain": "automation",
+            "name": "Blueprint Name",
+            "metadata": {
+                "input": {...},
+                "description": "..."
+            },
+            "definition": "..."
+        }
+
+    Note:
+        Blueprint ID typically includes domain and path.
+        If domain is not provided, attempts to extract it from blueprint_id.
+    """
+    client = await get_client()
+
+    # Blueprint ID typically includes domain and path
+    if domain:
+        url = f"{HA_URL}/api/blueprint/metadata/{domain}/{blueprint_id}"
+    else:
+        # Try to extract domain from blueprint_id
+        parts = blueprint_id.split("/")
+        if len(parts) >= 2:
+            domain = parts[0]
+            path = "/".join(parts[1:])
+            url = f"{HA_URL}/api/blueprint/metadata/{domain}/{path}"
+        else:
+            return {
+                "error": "Cannot determine domain for blueprint. Please provide domain parameter."
+            }
+
+    response = await client.get(url, headers=get_ha_headers())
+    response.raise_for_status()
+    return response.json()
+
+
+@handle_api_errors
+async def import_blueprint_from_url(url: str) -> dict[str, Any]:
+    """
+    Import blueprint from URL
+
+    Args:
+        url: The URL to import the blueprint from
+
+    Returns:
+        Response dictionary containing imported blueprint information
+
+    Example response:
+        {
+            "status": "imported",
+            "blueprint": {...}
+        }
+
+    Note:
+        This imports a blueprint from a community URL or external source.
+        The URL is URL-encoded when making the API request.
+    """
+    client = await get_client()
+
+    # URL encode the blueprint URL
+    encoded_url = urllib.parse.quote(url, safe="")
+
+    response = await client.get(
+        f"{HA_URL}/api/blueprint/import/{encoded_url}",
+        headers=get_ha_headers(),
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+@handle_api_errors
+async def create_automation_from_blueprint(
+    blueprint_id: str, inputs: dict[str, Any], domain: str | None = None
+) -> dict[str, Any]:
+    """
+    Create automation from blueprint with specified inputs
+
+    Args:
+        blueprint_id: The blueprint ID to use (may include domain and path)
+        inputs: Dictionary of input values for the blueprint
+        domain: Optional domain for the blueprint (e.g., 'automation')
+
+    Returns:
+        Response from the automation creation operation
+
+    Example response:
+        {
+            "automation_id": "automation_12345",
+            "status": "created"
+        }
+
+    Note:
+        This creates a new automation using a blueprint as a template.
+        The inputs dictionary must match the blueprint's input schema.
+        An automation ID will be generated if not provided in the inputs.
+    """
+    # Get blueprint definition first
+    blueprint = await get_blueprint_definition(blueprint_id, domain)
+
+    # Check for errors
+    if isinstance(blueprint, dict) and "error" in blueprint:
+        return blueprint
+
+    # Construct automation config from blueprint
+    # Extract domain from blueprint if not provided
+    if not domain:
+        domain = blueprint.get("domain", "automation")
+
+    # Construct automation config with blueprint reference
+    automation_config: dict[str, Any] = {
+        "use_blueprint": {
+            "path": blueprint.get("path", blueprint_id),
+            "input": inputs,
+        }
+    }
+
+    # Generate automation_id if not provided in inputs
+    automation_id = inputs.get("automation_id")
+    if not automation_id:
+        automation_id = f"automation_{uuid.uuid4().hex[:8]}"
+        automation_config["id"] = automation_id
+
+    # Use the create_automation function
+    return await create_automation(automation_config)


### PR DESCRIPTION
## Overview

This PR implements blueprint management tools for Home Assistant, allowing users to list, inspect, import, and create automations from blueprints.

## Changes

### New Functions in `app/hass.py`:
- `get_blueprints(domain=None)`: List all available blueprints, optionally filtered by domain
- `get_blueprint_definition(blueprint_id, domain=None)`: Get blueprint definition and metadata
- `import_blueprint_from_url(url)`: Import blueprint from URL
- `create_automation_from_blueprint(blueprint_id, inputs, domain=None)`: Create automation from blueprint

### New MCP Tools in `app/server.py`:
- `list_blueprints_tool`: List all available blueprints, optionally filtered by domain
- `get_blueprint_tool`: Get blueprint definition and metadata
- `import_blueprint_tool`: Import blueprint from URL
- `create_automation_from_blueprint_tool`: Create automation from blueprint with specified inputs

### Documentation Updates:
- Updated README.md to include new blueprint management tools in the "Available Tools" section

## Implementation Details

- Blueprints are reusable automation templates that simplify automation creation
- All functions include proper error handling via `@handle_api_errors` decorator
- Blueprint ID can include domain and path, or domain can be provided separately
- Automations created from blueprints automatically generate an ID if not provided in inputs
- URL encoding is handled automatically when importing blueprints

## Testing

- All linting checks pass
- Code follows existing patterns and conventions
- Functions include comprehensive docstrings with examples

## Related Issue

Closes #9