### PR TITLE
feat: Add Logbook Access Tools (closes #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,9 @@ Hass-MCP provides several tools for interacting with Home Assistant:
 - `create_zone`: Create a new zone with GPS coordinates and radius
 - `update_zone`: Update an existing zone (name, location, radius, icon)
 - `delete_zone`: Delete a zone (permanent, system zones may not be deletable)
+- `get_logbook`: Get logbook entries for a time range, optionally filtered by entity
+- `get_entity_logbook`: Get logbook entries for a specific entity
+- `search_logbook`: Search logbook entries by query string
 
 ## Prompts for Guided Conversations
 

--- a/app/hass.py
+++ b/app/hass.py
@@ -2761,3 +2761,151 @@ async def delete_zone(zone_id: str) -> dict[str, Any]:
     )
     response.raise_for_status()
     return {"status": "deleted", "zone_id": zone_id}
+
+
+@handle_api_errors
+async def get_logbook_entries(
+    timestamp: str | None = None,
+    entity_id: str | None = None,
+    hours: int = 24,
+) -> list[dict[str, Any]]:
+    """
+    Get logbook entries
+
+    Args:
+        timestamp: Optional timestamp to start from (ISO format, e.g., "2025-01-01T00:00:00Z")
+                   If not provided, calculated from hours parameter
+        entity_id: Optional entity ID to filter logbook entries by
+        hours: Number of hours of history to retrieve (default: 24, only used if timestamp is not provided)
+
+    Returns:
+        List of logbook entry dictionaries containing:
+        - when: Timestamp of the event
+        - name: Display name of the entity
+        - entity_id: The entity ID
+        - state: State change value
+        - domain: Entity domain
+        - message: Description of what happened
+        - icon: Icon associated with the event (if available)
+
+    Example response:
+        [
+            {
+                "when": "2025-03-15T10:30:00Z",
+                "name": "Living Room Light",
+                "entity_id": "light.living_room",
+                "state": "on",
+                "domain": "light",
+                "message": "turned on",
+                "icon": null
+            }
+        ]
+
+    Note:
+        The logbook records all state changes and events in Home Assistant.
+        Useful for debugging and auditing system behavior.
+        If timestamp is provided, hours parameter is ignored.
+
+    Best Practices:
+        - Keep hours reasonable (24-72) for token efficiency
+        - Use entity_id filter to focus on specific entities
+        - Use timestamp for precise time ranges
+    """
+    # Calculate timestamp if not provided
+    if not timestamp:
+        end_time = datetime.now(UTC)
+        start_time = end_time - timedelta(hours=hours)
+        timestamp = start_time.strftime("%Y-%m-%dT%H:%M:%S")
+    # Ensure timestamp doesn't have timezone info for API format
+    elif timestamp.endswith("Z"):
+        timestamp = timestamp[:-1]
+
+    client = await get_client()
+
+    # Build URL and params
+    url = f"{HA_URL}/api/logbook/{timestamp}"
+    params: dict[str, Any] = {}
+    if entity_id:
+        params["entity"] = entity_id
+
+    response = await client.get(url, headers=get_ha_headers(), params=params)
+    response.raise_for_status()
+    return response.json()
+
+
+@handle_api_errors
+async def get_entity_logbook_entries(entity_id: str, hours: int = 24) -> list[dict[str, Any]]:
+    """
+    Get logbook entries for a specific entity
+
+    Args:
+        entity_id: The entity ID to get logbook entries for
+        hours: Number of hours of history to retrieve (default: 24)
+
+    Returns:
+        List of logbook entry dictionaries for the specified entity
+
+    Examples:
+        entity_id="light.living_room", hours=24 - get last 24 hours of logbook for light
+        entity_id="sensor.temperature", hours=168 - get last 7 days of logbook for sensor
+
+    Note:
+        This is a convenience wrapper around get_logbook_entries with entity_id filter.
+        Returns only logbook entries for the specified entity.
+
+    Best Practices:
+        - Keep hours reasonable (24-72) for token efficiency
+        - Use this to debug specific entity behavior
+        - Check logbook to understand entity state changes over time
+    """
+    return await get_logbook_entries(entity_id=entity_id, hours=hours)
+
+
+@handle_api_errors
+async def search_logbook_entries(query: str, hours: int = 24) -> list[dict[str, Any]]:
+    """
+    Search logbook entries by query string
+
+    Args:
+        query: Search query to match against entity_id, name, or message
+        hours: Number of hours of history to search (default: 24)
+
+    Returns:
+        List of logbook entry dictionaries matching the query
+
+    Examples:
+        query="error" - find logbook entries containing "error"
+        query="sensor" - find logbook entries related to sensors
+        query="light.living_room" - find entries for specific entity
+
+    Note:
+        This searches through logbook entries using case-insensitive matching.
+        Searches in entity_id, name, and message fields.
+        Returns entries that contain the query string in any of these fields.
+
+    Best Practices:
+        - Keep hours reasonable (24-72) for token efficiency
+        - Use specific queries to find relevant entries
+        - Search for error messages, entity IDs, or specific events
+    """
+    # Get all logbook entries
+    entries = await get_logbook_entries(hours=hours)
+
+    # Filter entries matching query
+    query_lower = query.lower()
+    matching_entries = []
+
+    for entry in entries:
+        # Search in entity_id, name, message, etc.
+        entry_entity_id = entry.get("entity_id", "").lower()
+        entry_name = entry.get("name", "").lower()
+        entry_message = entry.get("message", "").lower()
+
+        if (
+            query_lower in entry_entity_id
+            or query_lower in entry_name
+            or query_lower in entry_message
+        ):
+            matching_entries.append(entry)
+
+    return matching_entries

--- a/app/server.py
+++ b/app/server.py
@@ -43,11 +43,13 @@ from app.hass import (
     get_devices,
     get_entities,
     get_entity_history,
+    get_entity_logbook_entries,
     get_entity_state,
     get_hass_error_log,
     get_hass_version,
     get_integration_config,
     get_integrations,
+    get_logbook_entries,
     get_scene_config,
     get_scenes,
     get_script_config,
@@ -61,6 +63,7 @@ from app.hass import (
     reload_scripts,
     restart_home_assistant,
     run_script,
+    search_logbook_entries,
     summarize_domain,
     test_template,
     trigger_automation,
@@ -2341,6 +2344,120 @@ async def delete_zone_tool(zone_id: str) -> dict[str, Any]:
     """
     logger.info(f"Deleting zone: {zone_id}")
     return await delete_zone(zone_id)
+
+
+@mcp.tool()
+@async_handler("get_logbook")
+async def get_logbook_tool(
+    timestamp: str | None = None,
+    entity_id: str | None = None,
+    hours: int = 24,
+) -> list[dict[str, Any]]:
+    """
+    Get logbook entries for a time range, optionally filtered by entity
+
+    Args:
+        timestamp: Optional timestamp to start from (ISO format, e.g., "2025-01-01T00:00:00Z")
+                   If not provided, calculated from hours parameter
+        entity_id: Optional entity ID to filter logbook entries by
+        hours: Number of hours of history to retrieve (default: 24, only used if timestamp is not provided)
+
+    Returns:
+        List of logbook entry dictionaries containing:
+        - when: Timestamp of the event
+        - name: Display name of the entity
+        - entity_id: The entity ID
+        - state: State change value
+        - domain: Entity domain
+        - message: Description of what happened
+        - icon: Icon associated with the event (if available)
+
+    Examples:
+        timestamp=None, entity_id=None, hours=24 - get last 24 hours of all logbook entries
+        timestamp=None, entity_id="light.living_room", hours=48 - get last 48 hours for specific entity
+        timestamp="2025-01-01T00:00:00Z", entity_id=None - get entries from specific timestamp
+
+    Note:
+        The logbook records all state changes and events in Home Assistant.
+        Useful for debugging and auditing system behavior.
+        If timestamp is provided, hours parameter is ignored.
+
+    Best Practices:
+        - Keep hours reasonable (24-72) for token efficiency
+        - Use entity_id filter to focus on specific entities
+        - Use timestamp for precise time ranges
+        - Use to debug state changes and events
+    """
+    logger.info(
+        "Getting logbook entries"
+        + (f" for entity: {entity_id}" if entity_id else "")
+        + (f" from timestamp: {timestamp}" if timestamp else f" for last {hours} hours")
+    )
+    return await get_logbook_entries(timestamp, entity_id, hours)
+
+
+@mcp.tool()
+@async_handler("get_entity_logbook")
+async def get_entity_logbook_tool(entity_id: str, hours: int = 24) -> list[dict[str, Any]]:
+    """
+    Get logbook entries for a specific entity
+
+    Args:
+        entity_id: The entity ID to get logbook entries for
+        hours: Number of hours of history to retrieve (default: 24)
+
+    Returns:
+        List of logbook entry dictionaries for the specified entity
+
+    Examples:
+        entity_id="light.living_room", hours=24 - get last 24 hours of logbook for light
+        entity_id="sensor.temperature", hours=168 - get last 7 days of logbook for sensor
+
+    Note:
+        This is a convenience wrapper around get_logbook with entity_id filter.
+        Returns only logbook entries for the specified entity.
+
+    Best Practices:
+        - Keep hours reasonable (24-72) for token efficiency
+        - Use this to debug specific entity behavior
+        - Check logbook to understand entity state changes over time
+        - Use to troubleshoot why an entity isn't working as expected
+    """
+    logger.info(f"Getting logbook entries for entity: {entity_id}, hours: {hours}")
+    return await get_entity_logbook_entries(entity_id, hours)
+
+
+@mcp.tool()
+@async_handler("search_logbook")
+async def search_logbook_tool(query: str, hours: int = 24) -> list[dict[str, Any]]:
+    """
+    Search logbook entries by query string
+
+    Args:
+        query: Search query to match against entity_id, name, or message
+        hours: Number of hours of history to search (default: 24)
+
+    Returns:
+        List of logbook entry dictionaries matching the query
+
+    Examples:
+        query="error" - find logbook entries containing "error"
+        query="sensor" - find logbook entries related to sensors
+        query="light.living_room" - find entries for specific entity
+
+    Note:
+        This searches through logbook entries using case-insensitive matching.
+        Searches in entity_id, name, and message fields.
+        Returns entries that contain the query string in any of these fields.
+
+    Best Practices:
+        - Keep hours reasonable (24-72) for token efficiency
+        - Use specific queries to find relevant entries
+        - Search for error messages, entity IDs, or specific events
+        - Use to find all events related to a specific topic or entity
+    """
+    logger.info(f"Searching logbook for query: '{query}', hours: {hours}")
+    return await search_logbook_entries(query, hours)
 
 
 # Prompt functionality


### PR DESCRIPTION
## Overview

This PR implements logbook access tools for Home Assistant, allowing users to retrieve, filter, and search logbook entries. The logbook records all state changes and events, which is essential for debugging and auditing.

## Changes

### New Functions in `app/hass.py`:
- `get_logbook_entries(timestamp=None, entity_id=None, hours=24)`: Get logbook entries for a time range, optionally filtered by entity
- `get_entity_logbook_entries(entity_id, hours=24)`: Get logbook entries for a specific entity
- `search_logbook_entries(query, hours=24)`: Search logbook entries by query string

### New MCP Tools in `app/server.py`:
- `get_logbook_tool`: Get logbook entries for a time range, optionally filtered by entity
- `get_entity_logbook_tool`: Get logbook entries for a specific entity
- `search_logbook_tool`: Search logbook entries by query string

### Documentation Updates:
- Updated README.md to include new logbook access tools in the "Available Tools" section

## Implementation Details

- Logbook functions support timestamp-based or hours-based time ranges
- Entity filtering allows focusing on specific entities
- Text search functionality matches against entity_id, name, and message fields
- Case-insensitive search for better usability
- All functions include proper error handling via `@handle_api_errors` decorator
- Timestamp handling supports ISO format with or without timezone indicator

## Testing

- All linting checks pass
- Code follows existing patterns and conventions
- Functions include comprehensive docstrings with examples
- Search functionality tested for entity_id, name, and message fields

## Related Issue

Closes #11