### PR TITLE
feat: Add Statistics and Analytics Tools (closes #12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,9 @@ Hass-MCP provides several tools for interacting with Home Assistant:
 - `get_logbook`: Get logbook entries for a time range, optionally filtered by entity
 - `get_entity_logbook`: Get logbook entries for a specific entity
 - `search_logbook`: Search logbook entries by query string
+- `get_entity_statistics`: Get statistics for an entity (min, max, mean, median)
+- `get_domain_statistics`: Get aggregate statistics for all entities in a domain
+- `analyze_usage_patterns`: Analyze usage patterns (when device is used most)
 
 ## Prompts for Guided Conversations
 

--- a/app/hass.py
+++ b/app/hass.py
@@ -2909,3 +2909,260 @@ async def search_logbook_entries(query: str, hours: int = 24) -> list[dict[str, 
             matching_entries.append(entry)
 
     return matching_entries
+
+
+@handle_api_errors
+async def get_entity_statistics(entity_id: str, period_days: int = 7) -> dict[str, Any]:
+    """
+    Get statistics for an entity (min, max, mean, median)
+
+    Args:
+        entity_id: The entity ID to get statistics for
+        period_days: Number of days to analyze (default: 7)
+
+    Returns:
+        Dictionary containing:
+        - entity_id: The entity ID analyzed
+        - period_days: Number of days analyzed
+        - data_points: Number of numeric data points found
+        - statistics: Dictionary with min, max, mean, median values
+        - note: Note if no data or entity is not numeric
+
+    Example response:
+        {
+            "entity_id": "sensor.temperature",
+            "period_days": 7,
+            "data_points": 1680,
+            "statistics": {
+                "min": 18.5,
+                "max": 24.3,
+                "mean": 21.4,
+                "median": 21.2
+            }
+        }
+
+    Note:
+        This calculates statistics from entity history data.
+        Only numeric entities can provide meaningful statistics.
+        Returns empty statistics if entity is not numeric or has no data.
+
+    Best Practices:
+        - Use for sensors with numeric values (temperature, humidity, etc.)
+        - Keep period_days reasonable (7-30) for performance
+        - Check for empty statistics if entity is not numeric
+    """
+    # Get history for the period
+    history = await get_entity_history(entity_id, hours=period_days * 24)
+
+    # Check for errors
+    if isinstance(history, dict) and "error" in history:
+        return {
+            "entity_id": entity_id,
+            "period_days": period_days,
+            "error": history["error"],
+            "statistics": {},
+        }
+
+    # Flatten history list (history is a list of lists)
+    states = []
+    if isinstance(history, list):
+        for state_list in history:
+            if isinstance(state_list, list):
+                states.extend(state_list)
+
+    if not states:
+        return {
+            "entity_id": entity_id,
+            "period_days": period_days,
+            "note": "No data available for the specified period",
+            "statistics": {},
+        }
+
+    # Extract numeric values
+    numeric_values = []
+    for state in states:
+        state_value = state.get("state")
+        try:
+            numeric_value = float(state_value)
+            numeric_values.append(numeric_value)
+        except (ValueError, TypeError):
+            continue
+
+    if not numeric_values:
+        return {
+            "entity_id": entity_id,
+            "period_days": period_days,
+            "note": "Entity state is not numeric, cannot calculate statistics",
+            "statistics": {},
+        }
+
+    # Calculate statistics
+    sorted_values = sorted(numeric_values)
+    n = len(numeric_values)
+    median = (
+        sorted_values[n // 2]
+        if n % 2 == 1
+        else (sorted_values[n // 2 - 1] + sorted_values[n // 2]) / 2
+    )
+
+    stats = {
+        "entity_id": entity_id,
+        "period_days": period_days,
+        "data_points": len(numeric_values),
+        "statistics": {
+            "min": min(numeric_values),
+            "max": max(numeric_values),
+            "mean": sum(numeric_values) / len(numeric_values),
+            "median": median,
+        },
+    }
+
+    return stats
+
+
+@handle_api_errors
+async def get_domain_statistics(domain: str, period_days: int = 7) -> dict[str, Any]:
+    """
+    Get aggregate statistics for all entities in a domain
+
+    Args:
+        domain: The domain to get statistics for (e.g., 'sensor', 'light')
+        period_days: Number of days to analyze (default: 7)
+
+    Returns:
+        Dictionary containing:
+        - domain: The domain analyzed
+        - period_days: Number of days analyzed
+        - total_entities: Total number of entities in the domain
+        - entity_statistics: Dictionary mapping entity_id to statistics
+
+    Example response:
+        {
+            "domain": "sensor",
+            "period_days": 7,
+            "total_entities": 25,
+            "entity_statistics": {
+                "sensor.temperature": {
+                    "min": 18.5,
+                    "max": 24.3,
+                    "mean": 21.4,
+                    "median": 21.2
+                }
+            }
+        }
+
+    Note:
+        This aggregates statistics for entities in a domain.
+        Limited to first 10 entities for performance.
+        Only numeric entities are included in entity_statistics.
+
+    Best Practices:
+        - Use for domains with numeric entities (sensor, energy, etc.)
+        - Keep period_days reasonable (7-30) for performance
+        - Consider using get_entity_statistics for individual entities
+    """
+    # Get all entities in domain
+    entities = await get_entities(domain=domain, lean=True)
+
+    stats: dict[str, Any] = {
+        "domain": domain,
+        "period_days": period_days,
+        "total_entities": len(entities),
+        "entity_statistics": {},
+    }
+
+    # Get statistics for each entity (limited to first 10 for performance)
+    for entity in entities[:10]:
+        entity_id = entity.get("entity_id")
+        if not entity_id:
+            continue
+        try:
+            entity_stats = await get_entity_statistics(entity_id, period_days)
+            # Only include entities with valid statistics
+            if entity_stats.get("statistics"):
+                stats["entity_statistics"][entity_id] = entity_stats.get("statistics", {})
+        except Exception:  # nosec B112
+            continue
+
+    return stats
+
+
+@handle_api_errors
+async def analyze_usage_patterns(entity_id: str, days: int = 30) -> dict[str, Any]:
+    """
+    Analyze usage patterns (when device is used most)
+
+    Args:
+        entity_id: The entity ID to analyze
+        days: Number of days to analyze (default: 30)
+
+    Returns:
+        Dictionary containing:
+        - entity_id: The entity ID analyzed
+        - period_days: Number of days analyzed
+        - total_events: Total number of logbook events
+        - hourly_distribution: Dictionary mapping hour (0-23) to event count
+        - daily_distribution: Dictionary mapping day name to event count
+        - peak_hour: Hour with most events (0-23)
+        - peak_day: Day of week with most events
+
+    Example response:
+        {
+            "entity_id": "light.living_room",
+            "period_days": 30,
+            "total_events": 150,
+            "hourly_distribution": {18: 30, 19: 25, 20: 20, ...},
+            "daily_distribution": {"Monday": 25, "Tuesday": 22, ...},
+            "peak_hour": 18,
+            "peak_day": "Monday"
+        }
+
+    Note:
+        This analyzes logbook entries to find usage patterns.
+        Useful for understanding when devices are used most.
+        Helps optimize automations based on actual usage.
+
+    Best Practices:
+        - Use for devices with frequent state changes (lights, switches, etc.)
+        - Keep days reasonable (7-30) for performance
+        - Use results to optimize automation schedules
+    """
+    # Get logbook entries
+    logbook = await get_entity_logbook_entries(entity_id, hours=days * 24)
+
+    # Analyze by hour of day
+    hourly_usage: dict[int, int] = {}
+    daily_usage: dict[str, int] = {}
+
+    for entry in logbook:
+        when = entry.get("when")
+        if when:
+            try:
+                # Parse timestamp (handle both with and without timezone)
+                if when.endswith("Z"):
+                    dt = datetime.fromisoformat(when.replace("Z", "+00:00"))
+                else:
+                    dt = datetime.fromisoformat(when)
+
+                hour = dt.hour
+                hourly_usage[hour] = hourly_usage.get(hour, 0) + 1
+
+                # Analyze by day of week
+                day = dt.strftime("%A")
+                daily_usage[day] = daily_usage.get(day, 0) + 1
+            except (ValueError, AttributeError):  # nosec B110
+                continue
+
+    # Find peak hour and day
+    peak_hour = max(hourly_usage.items(), key=lambda x: x[1])[0] if hourly_usage else None
+    peak_day = max(daily_usage.items(), key=lambda x: x[1])[0] if daily_usage else None
+
+    return {
+        "entity_id": entity_id,
+        "period_days": days,
+        "total_events": len(logbook),
+        "hourly_distribution": hourly_usage,
+        "daily_distribution": daily_usage,
+        "peak_hour": peak_hour,
+        "peak_day": peak_day,
+    }

--- a/app/server.py
+++ b/app/server.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 
 from app.hass import (
     activate_scene,
+    analyze_usage_patterns,
     call_service,
     create_area,
     create_automation_from_blueprint,
@@ -41,10 +42,12 @@ from app.hass import (
     get_device_entities,
     get_device_statistics,
     get_devices,
+    get_domain_statistics,
     get_entities,
     get_entity_history,
     get_entity_logbook_entries,
     get_entity_state,
+    get_entity_statistics,
     get_hass_error_log,
     get_hass_version,
     get_integration_config,
@@ -2458,6 +2461,118 @@ async def search_logbook_tool(query: str, hours: int = 24) -> list[dict[str, Any
     """
     logger.info(f"Searching logbook for query: '{query}', hours: {hours}")
     return await search_logbook_entries(query, hours)
+
+
+@mcp.tool()
+@async_handler("get_entity_statistics")
+async def get_entity_statistics_tool(entity_id: str, period_days: int = 7) -> dict[str, Any]:
+    """
+    Get statistics for an entity (min, max, mean, median)
+
+    Args:
+        entity_id: The entity ID to get statistics for
+        period_days: Number of days to analyze (default: 7)
+
+    Returns:
+        Dictionary containing:
+        - entity_id: The entity ID analyzed
+        - period_days: Number of days analyzed
+        - data_points: Number of numeric data points found
+        - statistics: Dictionary with min, max, mean, median values
+        - note: Note if no data or entity is not numeric
+
+    Examples:
+        entity_id="sensor.temperature", period_days=7 - get temperature statistics for last week
+        entity_id="sensor.humidity", period_days=30 - get humidity statistics for last month
+
+    Note:
+        This calculates statistics from entity history data.
+        Only numeric entities can provide meaningful statistics.
+        Returns empty statistics if entity is not numeric or has no data.
+
+    Best Practices:
+        - Use for sensors with numeric values (temperature, humidity, etc.)
+        - Keep period_days reasonable (7-30) for performance
+        - Check for empty statistics if entity is not numeric
+        - Use to analyze energy consumption, temperature trends, etc.
+    """
+    logger.info(f"Getting statistics for entity: {entity_id}, period_days: {period_days}")
+    return await get_entity_statistics(entity_id, period_days)
+
+
+@mcp.tool()
+@async_handler("get_domain_statistics")
+async def get_domain_statistics_tool(domain: str, period_days: int = 7) -> dict[str, Any]:
+    """
+    Get aggregate statistics for all entities in a domain
+
+    Args:
+        domain: The domain to get statistics for (e.g., 'sensor', 'light')
+        period_days: Number of days to analyze (default: 7)
+
+    Returns:
+        Dictionary containing:
+        - domain: The domain analyzed
+        - period_days: Number of days analyzed
+        - total_entities: Total number of entities in the domain
+        - entity_statistics: Dictionary mapping entity_id to statistics
+
+    Examples:
+        domain="sensor", period_days=7 - get statistics for all sensors over last week
+        domain="energy", period_days=30 - get statistics for all energy entities over last month
+
+    Note:
+        This aggregates statistics for entities in a domain.
+        Limited to first 10 entities for performance.
+        Only numeric entities are included in entity_statistics.
+
+    Best Practices:
+        - Use for domains with numeric entities (sensor, energy, etc.)
+        - Keep period_days reasonable (7-30) for performance
+        - Consider using get_entity_statistics for individual entities
+        - Use to analyze trends across multiple entities in a domain
+    """
+    logger.info(f"Getting statistics for domain: {domain}, period_days: {period_days}")
+    return await get_domain_statistics(domain, period_days)
+
+
+@mcp.tool()
+@async_handler("analyze_usage_patterns")
+async def analyze_usage_patterns_tool(entity_id: str, days: int = 30) -> dict[str, Any]:
+    """
+    Analyze usage patterns (when device is used most)
+
+    Args:
+        entity_id: The entity ID to analyze
+        days: Number of days to analyze (default: 30)
+
+    Returns:
+        Dictionary containing:
+        - entity_id: The entity ID analyzed
+        - period_days: Number of days analyzed
+        - total_events: Total number of logbook events
+        - hourly_distribution: Dictionary mapping hour (0-23) to event count
+        - daily_distribution: Dictionary mapping day name to event count
+        - peak_hour: Hour with most events (0-23)
+        - peak_day: Day of week with most events
+
+    Examples:
+        entity_id="light.living_room", days=30 - analyze light usage patterns over last month
+        entity_id="switch.kitchen", days=7 - analyze switch usage patterns over last week
+
+    Note:
+        This analyzes logbook entries to find usage patterns.
+        Useful for understanding when devices are used most.
+        Helps optimize automations based on actual usage.
+
+    Best Practices:
+        - Use for devices with frequent state changes (lights, switches, etc.)
+        - Keep days reasonable (7-30) for performance
+        - Use results to optimize automation schedules
+        - Use to identify peak usage times for energy optimization
+    """
+    logger.info(f"Analyzing usage patterns for entity: {entity_id}, days: {days}")
+    return await analyze_usage_patterns(entity_id, days)
 
 
 # Prompt functionality


### PR DESCRIPTION
## Overview

This PR implements statistics and analytics tools for Home Assistant, allowing users to retrieve statistics for entities, aggregate statistics for domains, and analyze usage patterns. This is useful for analyzing usage patterns, energy consumption, and long-term trends.

## Changes

### New Functions in `app/hass.py`:
- `get_entity_statistics(entity_id, period_days=7)`: Calculate statistics (min, max, mean, median) for numeric entities
- `get_domain_statistics(domain, period_days=7)`: Aggregate statistics for all entities in a domain
- `analyze_usage_patterns(entity_id, days=30)`: Analyze usage patterns by time of day and day of week

### New MCP Tools in `app/server.py`:
- `get_entity_statistics_tool`: Get statistics for an entity (min, max, mean, median)
- `get_domain_statistics_tool`: Get aggregate statistics for all entities in a domain
- `analyze_usage_patterns_tool`: Analyze usage patterns (when device is used most)

### Documentation Updates:
- Updated README.md to include new statistics and analytics tools in the "Available Tools" section

## Implementation Details

- Statistics functions extract numeric values from entity history data
- Calculates min, max, mean, and median for numeric entities
- Domain statistics limited to first 10 entities for performance
- Usage pattern analysis uses logbook entries to find peak usage times
- Analyzes usage by hour of day (0-23) and day of week
- Identifies peak hour and peak day for optimization
- All functions include proper error handling via `@handle_api_errors` decorator
- Handles non-numeric entities gracefully

## Testing

- All linting checks pass
- Code follows existing patterns and conventions
- Functions include comprehensive docstrings with examples
- Statistics calculations tested for numeric entities
- Usage pattern analysis tested for devices with state changes

## Related Issue

Closes #12