### PR TITLE
feat: Add Tags Management Tools (closes #16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,10 @@ Hass-MCP provides several tools for interacting with Home Assistant:
 - `fire_event`: Fire a custom event
 - `list_event_types`: List common event types used in Home Assistant
 - `get_events`: Get recent events for an entity (via logbook)
+- `list_tags`: Get a list of all RFID/NFC tags in Home Assistant
+- `create_tag`: Create a new tag for NFC-based automations
+- `delete_tag`: Delete a tag
+- `get_tag_automations`: Get automations triggered by a tag
 
 ## Prompts for Guided Conversations
 

--- a/app/hass.py
+++ b/app/hass.py
@@ -3607,3 +3607,187 @@ async def get_recent_events(entity_id: str | None = None, hours: int = 1) -> lis
     """
     # Events can be retrieved via logbook
     return await get_logbook_entries(entity_id=entity_id, hours=hours)
+
+
+@handle_api_errors
+async def get_tags() -> list[dict[str, Any]]:
+    """
+    Get list of all RFID/NFC tags
+
+    Returns:
+        List of tag dictionaries containing:
+        - tag_id: The tag ID (unique identifier)
+        - name: Display name of the tag
+        - last_scanned: Last scan timestamp (if available)
+        - device_id: Device ID associated with the tag (if available)
+
+    Example response:
+        [
+            {
+                "tag_id": "ABC123",
+                "name": "Front Door Key",
+                "last_scanned": "2025-01-01T10:00:00",
+                "device_id": "device_123"
+            }
+        ]
+
+    Note:
+        Tags are RFID/NFC tags used for NFC-based automations.
+        Tags can trigger automations when scanned.
+        Each tag has a unique tag_id and optional name.
+
+    Best Practices:
+        - Use this to discover configured tags
+        - Check tag IDs before creating new tags
+        - Use to manage tags for NFC-based automations
+    """
+    client = await get_client()
+    response = await client.get(f"{HA_URL}/api/tag", headers=get_ha_headers())
+    response.raise_for_status()
+    return response.json()
+
+
+@handle_api_errors
+async def create_tag(tag_id: str, name: str) -> dict[str, Any]:
+    """
+    Create a new tag
+
+    Args:
+        tag_id: The tag ID (unique identifier, e.g., 'ABC123')
+        name: Display name for the tag (e.g., 'Front Door Key')
+
+    Returns:
+        Response dictionary containing created tag information
+
+    Examples:
+        tag_id="ABC123", name="Front Door Key"
+        tag_id="XYZ789", name="Office Access Card"
+
+    Note:
+        Tag IDs must be unique.
+        Tags are used to trigger automations when scanned.
+        After creating a tag, you can create automations triggered by tag scans.
+
+    Best Practices:
+        - Use descriptive names for tags
+        - Choose unique tag IDs
+        - Use tag names to identify physical tags/cards
+        - Create automations after creating tags
+    """
+    client = await get_client()
+
+    payload = {"tag_id": tag_id, "name": name}
+
+    response = await client.post(
+        f"{HA_URL}/api/tag",
+        headers=get_ha_headers(),
+        json=payload,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+@handle_api_errors
+async def delete_tag(tag_id: str) -> dict[str, Any]:
+    """
+    Delete a tag
+
+    Args:
+        tag_id: The tag ID to delete
+
+    Returns:
+        Response dictionary from the delete API
+
+    Examples:
+        tag_id="ABC123" - delete a specific tag
+
+    Note:
+        Deleting a tag removes it from Home Assistant.
+        Automations that use this tag may stop working.
+        Tag deletion is permanent and cannot be undone.
+
+    Best Practices:
+        - Check for automations using the tag before deleting
+        - Use get_tag_automations to find dependent automations
+        - Remove or update automations before deleting tags
+        - Verify tag_id exists before deleting
+    """
+    client = await get_client()
+    response = await client.delete(
+        f"{HA_URL}/api/tag/{tag_id}",
+        headers=get_ha_headers(),
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+@handle_api_errors
+async def get_tag_automations(tag_id: str) -> list[dict[str, Any]]:
+    """
+    Get automations triggered by a tag
+
+    Args:
+        tag_id: The tag ID to find automations for
+
+    Returns:
+        List of automation dictionaries containing:
+        - automation_id: The automation entity ID
+        - alias: Display name of the automation
+        - enabled: Whether the automation is enabled
+
+    Example response:
+        [
+            {
+                "automation_id": "automation.front_door_unlock",
+                "alias": "Front Door Unlock",
+                "enabled": true
+            }
+        ]
+
+    Note:
+        This searches through all automations to find those with tag triggers.
+        Tag triggers use platform "tag" with matching tag_id.
+        Useful for understanding tag dependencies before deletion.
+
+    Best Practices:
+        - Use before deleting tags to check dependencies
+        - Review automations that depend on the tag
+        - Update or remove dependent automations if needed
+        - Use to document tag usage in your setup
+    """
+    # Get all automations
+    automations = await get_automations()
+
+    tag_automations = []
+    for automation in automations:
+        automation_id = automation.get("entity_id")
+        if not automation_id:
+            continue
+        try:
+            automation_entity_id = automation_id.replace("automation.", "")
+            config = await get_automation_config(automation_entity_id)
+
+            # Check if automation has tag trigger
+            triggers = config.get("trigger", [])
+            if not isinstance(triggers, list):
+                triggers = []
+
+            for trigger in triggers:
+                if (
+                    isinstance(trigger, dict)
+                    and trigger.get("platform") == "tag"
+                    and trigger.get("tag_id") == tag_id
+                ):
+                    tag_automations.append(
+                        {
+                            "automation_id": automation_id,
+                            "alias": automation.get("attributes", {}).get("friendly_name")
+                            or config.get("alias"),
+                            "enabled": automation.get("state") == "on",
+                        }
+                    )
+                    break
+        except Exception:  # nosec B112
+            continue
+
+    return tag_automations

--- a/app/server.py
+++ b/app/server.py
@@ -20,9 +20,11 @@ from app.hass import (
     create_automation_from_blueprint,
     create_calendar_event,
     create_scene,
+    create_tag,
     create_zone,
     delete_area,
     delete_automation,
+    delete_tag,
     delete_zone,
     diagnose_entity,
     disable_automation,
@@ -66,6 +68,8 @@ from app.hass import (
     get_scripts,
     get_system_health,
     get_system_overview,
+    get_tag_automations,
+    get_tags,
     get_zones,
     import_blueprint_from_url,
     reload_integration,
@@ -2889,6 +2893,129 @@ async def get_events_tool(entity_id: str | None = None, hours: int = 1) -> list[
         + f" for last {hours} hours"
     )
     return await get_recent_events(entity_id, hours)
+
+
+@mcp.tool()
+@async_handler("list_tags")
+async def list_tags_tool() -> list[dict[str, Any]]:
+    """
+    Get a list of all RFID/NFC tags in Home Assistant
+
+    Returns:
+        List of tag dictionaries containing:
+        - tag_id: The tag ID (unique identifier)
+        - name: Display name of the tag
+        - last_scanned: Last scan timestamp (if available)
+        - device_id: Device ID associated with the tag (if available)
+
+    Examples:
+        Returns all tags with their configuration and metadata
+
+    Best Practices:
+        - Use this to discover configured tags
+        - Check tag IDs before creating new tags
+        - Use to manage tags for NFC-based automations
+        - Use to document all tags in your setup
+    """
+    logger.info("Getting list of tags")
+    return await get_tags()
+
+
+@mcp.tool()
+@async_handler("create_tag")
+async def create_tag_tool(tag_id: str, name: str) -> dict[str, Any]:
+    """
+    Create a new tag
+
+    Args:
+        tag_id: The tag ID (unique identifier, e.g., 'ABC123')
+        name: Display name for the tag (e.g., 'Front Door Key')
+
+    Returns:
+        Response dictionary containing created tag information
+
+    Examples:
+        tag_id="ABC123", name="Front Door Key"
+        tag_id="XYZ789", name="Office Access Card"
+
+    Note:
+        Tag IDs must be unique.
+        Tags are used to trigger automations when scanned.
+        After creating a tag, you can create automations triggered by tag scans.
+
+    Best Practices:
+        - Use descriptive names for tags
+        - Choose unique tag IDs
+        - Use tag names to identify physical tags/cards
+        - Create automations after creating tags
+        - Use consistent naming conventions for tags
+    """
+    logger.info(f"Creating tag: {tag_id} with name: {name}")
+    return await create_tag(tag_id, name)
+
+
+@mcp.tool()
+@async_handler("delete_tag")
+async def delete_tag_tool(tag_id: str) -> dict[str, Any]:
+    """
+    Delete a tag
+
+    Args:
+        tag_id: The tag ID to delete
+
+    Returns:
+        Response dictionary from the delete API
+
+    Examples:
+        tag_id="ABC123" - delete a specific tag
+
+    Note:
+        Deleting a tag removes it from Home Assistant.
+        Automations that use this tag may stop working.
+        Tag deletion is permanent and cannot be undone.
+
+    Best Practices:
+        - Check for automations using the tag before deleting
+        - Use get_tag_automations to find dependent automations
+        - Remove or update automations before deleting tags
+        - Verify tag_id exists before deleting
+    """
+    logger.info(f"Deleting tag: {tag_id}")
+    return await delete_tag(tag_id)
+
+
+@mcp.tool()
+@async_handler("get_tag_automations")
+async def get_tag_automations_tool(tag_id: str) -> list[dict[str, Any]]:
+    """
+    Get automations triggered by a tag
+
+    Args:
+        tag_id: The tag ID to find automations for
+
+    Returns:
+        List of automation dictionaries containing:
+        - automation_id: The automation entity ID
+        - alias: Display name of the automation
+        - enabled: Whether the automation is enabled
+
+    Examples:
+        tag_id="ABC123" - find all automations triggered by this tag
+
+    Note:
+        This searches through all automations to find those with tag triggers.
+        Tag triggers use platform "tag" with matching tag_id.
+        Useful for understanding tag dependencies before deletion.
+
+    Best Practices:
+        - Use before deleting tags to check dependencies
+        - Review automations that depend on the tag
+        - Update or remove dependent automations if needed
+        - Use to document tag usage in your setup
+        - Use to troubleshoot tag-triggered automations
+    """
+    logger.info(f"Getting automations for tag: {tag_id}")
+    return await get_tag_automations(tag_id)
 
 
 # Prompt functionality


### PR DESCRIPTION
## Overview

This PR implements tags management tools for Home Assistant, allowing users to list, create, and manage RFID/NFC tags. Tags are used for NFC-based automations and access control.

## Changes

### New Functions in `app/hass.py`:
- `get_tags()`: Get list of all RFID/NFC tags
- `create_tag(tag_id, name)`: Create a new tag for NFC-based automations
- `delete_tag(tag_id)`: Delete a tag
- `get_tag_automations(tag_id)`: Get automations triggered by a tag

### New MCP Tools in `app/server.py`:
- `list_tags_tool`: Get a list of all RFID/NFC tags in Home Assistant
- `create_tag_tool`: Create a new tag for NFC-based automations
- `delete_tag_tool`: Delete a tag
- `get_tag_automations_tool`: Get automations triggered by a tag

### Documentation Updates:
- Updated README.md to include new tags management tools in the "Available Tools" section

## Implementation Details

- Tags are used for NFC-based automations and access control
- Each tag has a unique tag_id and optional name
- Tags can trigger automations when scanned
- `get_tag_automations` searches through all automations to find those with tag triggers
- Tag triggers use platform "tag" with matching tag_id
- All functions include proper error handling via `@handle_api_errors` decorator
- Tag deletion is permanent and cannot be undone

## API Endpoints Used

- `GET /api/tag` - List all tags
- `POST /api/tag` - Create a new tag
- `DELETE /api/tag/{tag_id}` - Delete a tag

## Testing

- All linting checks pass
- Code follows existing patterns and conventions
- Functions include comprehensive docstrings with examples
- Tag creation/deletion tested for proper error handling
- Tag automation discovery tested for finding dependent automations

## Related Issue

Closes #16