### PR TITLE
Phase 2.3: Extract Scripts domain API

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -26,6 +26,12 @@ from app.api.entities import (
     get_entity_history,
     get_entity_state,
 )
+from app.api.scripts import (
+    get_script_config,
+    get_scripts,
+    reload_scripts,
+    run_script,
+)
 
 __all__ = [
     "BaseAPI",
@@ -45,4 +51,8 @@ __all__ = [
     "trigger_automation",
     "get_automation_execution_log",
     "validate_automation_config",
+    "get_scripts",
+    "get_script_config",
+    "run_script",
+    "reload_scripts",
 ]

--- a/app/api/scripts.py
+++ b/app/api/scripts.py
@@ -1,0 +1,184 @@
+"""Scripts API module for hass-mcp.
+
+This module provides functions for interacting with Home Assistant scripts.
+"""
+
+import logging
+from typing import Any, cast
+
+from app.api.entities import get_entities, get_entity_state
+from app.config import HA_URL, get_ha_headers
+from app.core import get_client
+from app.core.decorators import handle_api_errors
+
+logger = logging.getLogger(__name__)
+
+
+@handle_api_errors
+async def get_scripts() -> list[dict[str, Any]]:
+    """
+    Get list of all scripts from Home Assistant.
+
+    Returns:
+        List of script dictionaries containing:
+        - entity_id: The script entity ID (e.g., 'script.turn_on_lights')
+        - state: Current state of the script
+        - friendly_name: Display name of the script
+        - last_triggered: Timestamp of last execution (if available)
+        - alias: Script alias/name
+
+    Example response:
+        [
+            {
+                "entity_id": "script.turn_on_lights",
+                "state": "idle",
+                "friendly_name": "Turn on lights",
+                "alias": "Turn on lights",
+                "last_triggered": "2025-01-01T12:00:00Z"
+            }
+        ]
+    """
+    # Scripts can be retrieved via states API
+    script_entities = await get_entities(domain="script")
+
+    # Check if we got an error response
+    if isinstance(script_entities, dict) and "error" in script_entities:
+        return cast(list[dict[str, Any]], script_entities)  # Just pass through the error
+
+    # Extract script information
+    scripts = []
+    try:
+        for entity in script_entities:
+            script_info = {
+                "entity_id": entity.get("entity_id"),
+                "state": entity.get("state"),
+            }
+
+            # Add attributes if available
+            attributes = entity.get("attributes", {})
+            if "friendly_name" in attributes:
+                script_info["friendly_name"] = attributes["friendly_name"]
+            if "alias" in attributes:
+                script_info["alias"] = attributes["alias"]
+            if "last_triggered" in attributes:
+                script_info["last_triggered"] = attributes["last_triggered"]
+
+            scripts.append(script_info)
+    except (TypeError, KeyError) as e:
+        # Handle errors in processing the entities
+        return {"error": f"Error processing script entities: {str(e)}"}
+
+    return scripts
+
+
+@handle_api_errors
+async def get_script_config(script_id: str) -> dict[str, Any]:
+    """
+    Get script configuration (sequence of actions).
+
+    Args:
+        script_id: The script ID to get (without 'script.' prefix)
+
+    Returns:
+        Script configuration dictionary with:
+        - entity_id: The script entity ID
+        - state: Current state
+        - attributes: Script attributes including configuration
+        - config: Script configuration if available via config API
+
+    Example response:
+        {
+            "entity_id": "script.turn_on_lights",
+            "state": "idle",
+            "attributes": {...},
+            "sequence": [
+                {"service": "light.turn_on", "entity_id": "light.living_room"}
+            ]
+        }
+
+    Note:
+        Script configuration might be available via config API or
+        only through entity state depending on Home Assistant version.
+        This function tries the config API first, then falls back to entity state.
+    """
+    entity_id = f"script.{script_id}"
+
+    # Try to get config via config API if available
+    try:
+        client = await get_client()
+        response = await client.get(
+            f"{HA_URL}/api/config/scripts/{script_id}",
+            headers=get_ha_headers(),
+        )
+        if response.status_code == 200:
+            config_data = response.json()
+            # Merge with entity state for complete information
+            entity = await get_entity_state(entity_id, lean=False)
+            config_data["entity"] = entity
+            return cast(dict[str, Any], config_data)
+    except Exception:  # nosec B110
+        # Config API not available, fall through to entity state
+        pass
+
+    # Fallback to entity state
+    return await get_entity_state(entity_id, lean=False)
+
+
+@handle_api_errors
+async def run_script(script_id: str, variables: dict[str, Any] | None = None) -> dict[str, Any]:
+    """
+    Execute a script with optional variables.
+
+    Args:
+        script_id: The script ID to execute (without 'script.' prefix)
+        variables: Optional dictionary of variables to pass to the script
+
+    Returns:
+        Response from the script execution (usually empty for successful calls)
+
+    Examples:
+        # Run script without variables
+        result = await run_script("turn_on_lights")
+
+        # Run script with variables
+        result = await run_script("notify", {"message": "Hello", "target": "user1"})
+
+    Note:
+        Scripts execute asynchronously. The response indicates the script was started,
+        not necessarily that it completed.
+    """
+    data: dict[str, Any] = {}
+    if variables:
+        data["variables"] = variables
+
+    # Call script service directly via httpx
+    client = await get_client()
+    response = await client.post(
+        f"{HA_URL}/api/services/script/{script_id}",
+        headers=get_ha_headers(),
+        json=data,
+    )
+    response.raise_for_status()
+    return cast(dict[str, Any], response.json())
+
+
+@handle_api_errors
+async def reload_scripts() -> dict[str, Any]:
+    """
+    Reload all scripts from configuration.
+
+    Returns:
+        Response from the reload operation (usually empty for successful calls)
+
+    Note:
+        Reloading scripts reloads all script configurations from YAML files.
+        This is useful after modifying script configuration files.
+    """
+    client = await get_client()
+    response = await client.post(
+        f"{HA_URL}/api/services/script/reload",
+        headers=get_ha_headers(),
+        json={},
+    )
+    response.raise_for_status()
+    return cast(dict[str, Any], response.json())

--- a/tests/unit/test_api_scripts.py
+++ b/tests/unit/test_api_scripts.py
@@ -1,0 +1,279 @@
+"""Unit tests for app.api.scripts module."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from app.api.scripts import (
+    get_script_config,
+    get_scripts,
+    reload_scripts,
+    run_script,
+)
+
+
+class TestGetScripts:
+    """Test the get_scripts function."""
+
+    @pytest.fixture(autouse=True)
+    def mock_config(self):
+        """Mock HA_URL and HA_TOKEN for all tests in this class."""
+        with (
+            patch("app.config.HA_URL", "http://localhost:8123"),
+            patch("app.config.HA_TOKEN", "test_token"),
+            patch("app.core.decorators.HA_TOKEN", "test_token"),
+        ):
+            yield
+
+    @pytest.mark.asyncio
+    async def test_get_scripts_success(self):
+        """Test successful retrieval of scripts."""
+        mock_script_entities = [
+            {
+                "entity_id": "script.turn_on_lights",
+                "state": "idle",
+                "attributes": {
+                    "friendly_name": "Turn on lights",
+                    "alias": "Turn on lights",
+                    "last_triggered": "2025-01-01T10:00:00Z",
+                },
+            },
+            {
+                "entity_id": "script.notify_user",
+                "state": "running",
+                "attributes": {"friendly_name": "Notify user"},
+            },
+        ]
+
+        with patch("app.api.scripts.get_entities", return_value=mock_script_entities):
+            result = await get_scripts()
+
+            assert isinstance(result, list)
+            assert len(result) == 2
+            assert result[0]["entity_id"] == "script.turn_on_lights"
+            assert result[0]["state"] == "idle"
+            assert result[0]["friendly_name"] == "Turn on lights"
+            assert result[0]["alias"] == "Turn on lights"
+            assert result[0]["last_triggered"] == "2025-01-01T10:00:00Z"
+            assert result[1]["entity_id"] == "script.notify_user"
+            assert result[1]["state"] == "running"
+            assert result[1]["friendly_name"] == "Notify user"
+
+    @pytest.mark.asyncio
+    async def test_get_scripts_error_response(self):
+        """Test handling of error response from get_entities."""
+        error_response = {"error": "Connection error"}
+
+        with patch("app.api.scripts.get_entities", return_value=error_response):
+            result = await get_scripts()
+
+            assert isinstance(result, dict)
+            assert "error" in result
+            assert result["error"] == "Connection error"
+
+    @pytest.mark.asyncio
+    async def test_get_scripts_processing_error(self):
+        """Test handling of processing errors."""
+        # Test with entity that will raise KeyError when accessing nested attributes
+        invalid_entities = [{"entity_id": "script.test", "state": "idle", "attributes": None}]
+
+        with patch("app.api.scripts.get_entities", return_value=invalid_entities):
+            result = await get_scripts()
+
+            # When processing fails due to invalid structure, function returns error dict
+            assert isinstance(result, dict)
+            assert "error" in result
+            assert "Error processing script entities" in result["error"]
+
+
+class TestGetScriptConfig:
+    """Test the get_script_config function."""
+
+    @pytest.fixture(autouse=True)
+    def mock_config(self):
+        """Mock HA_URL and HA_TOKEN for all tests in this class."""
+        with (
+            patch("app.config.HA_URL", "http://localhost:8123"),
+            patch("app.config.HA_TOKEN", "test_token"),
+            patch("app.core.decorators.HA_TOKEN", "test_token"),
+        ):
+            yield
+
+    @pytest.mark.asyncio
+    async def test_get_script_config_via_config_api(self):
+        """Test getting script config via config API."""
+        script_id = "test_script"
+        mock_config_data = {
+            "sequence": [{"service": "light.turn_on", "entity_id": "light.test"}],
+            "alias": "Test Script",
+        }
+        mock_entity = {
+            "entity_id": "script.test_script",
+            "state": "idle",
+            "attributes": {"friendly_name": "Test Script"},
+        }
+
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = mock_config_data
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch("app.api.scripts.get_client", return_value=mock_client):
+            with patch("app.api.scripts.get_entity_state", return_value=mock_entity):
+                result = await get_script_config(script_id)
+
+                assert result["sequence"] == mock_config_data["sequence"]
+                assert result["entity"] == mock_entity
+                mock_client.get.assert_called_once()
+                call_args = mock_client.get.call_args
+                assert call_args[0][0] == f"http://localhost:8123/api/config/scripts/{script_id}"
+                assert call_args[1]["headers"]["Authorization"] == "Bearer test_token"
+
+    @pytest.mark.asyncio
+    async def test_get_script_config_fallback_to_entity_state(self):
+        """Test fallback to entity state when config API unavailable."""
+        script_id = "test_script"
+        mock_entity = {
+            "entity_id": "script.test_script",
+            "state": "idle",
+            "attributes": {"friendly_name": "Test Script"},
+        }
+
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 404  # Config API not available
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch("app.api.scripts.get_client", return_value=mock_client):
+            with patch("app.api.scripts.get_entity_state", return_value=mock_entity):
+                result = await get_script_config(script_id)
+
+                assert result == mock_entity
+                assert result["entity_id"] == "script.test_script"
+
+    @pytest.mark.asyncio
+    async def test_get_script_config_exception_fallback(self):
+        """Test fallback when exception occurs."""
+        script_id = "test_script"
+        mock_entity = {
+            "entity_id": "script.test_script",
+            "state": "idle",
+            "attributes": {"friendly_name": "Test Script"},
+        }
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=Exception("API error"))
+
+        with patch("app.api.scripts.get_client", return_value=mock_client):
+            with patch("app.api.scripts.get_entity_state", return_value=mock_entity):
+                result = await get_script_config(script_id)
+
+                assert result == mock_entity
+
+
+class TestRunScript:
+    """Test the run_script function."""
+
+    @pytest.fixture(autouse=True)
+    def mock_config(self):
+        """Mock HA_URL and HA_TOKEN for all tests in this class."""
+        with (
+            patch("app.config.HA_URL", "http://localhost:8123"),
+            patch("app.config.HA_TOKEN", "test_token"),
+            patch("app.core.decorators.HA_TOKEN", "test_token"),
+        ):
+            yield
+
+    @pytest.mark.asyncio
+    async def test_run_script_without_variables(self):
+        """Test running script without variables."""
+        script_id = "turn_on_lights"
+
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {}
+        mock_response.raise_for_status = MagicMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch("app.api.scripts.get_client", return_value=mock_client):
+            result = await run_script(script_id)
+
+            assert result == {}
+            mock_client.post.assert_called_once()
+            call_args = mock_client.post.call_args
+            assert call_args[0][0] == f"http://localhost:8123/api/services/script/{script_id}"
+            assert call_args[1]["headers"]["Authorization"] == "Bearer test_token"
+            assert call_args[1]["json"] == {}
+
+    @pytest.mark.asyncio
+    async def test_run_script_with_variables(self):
+        """Test running script with variables."""
+        script_id = "notify_user"
+        variables = {"message": "Hello", "target": "user1"}
+
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {}
+        mock_response.raise_for_status = MagicMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch("app.api.scripts.get_client", return_value=mock_client):
+            result = await run_script(script_id, variables)
+
+            assert result == {}
+            mock_client.post.assert_called_once()
+            call_args = mock_client.post.call_args
+            assert call_args[0][0] == f"http://localhost:8123/api/services/script/{script_id}"
+            assert call_args[1]["headers"]["Authorization"] == "Bearer test_token"
+            assert call_args[1]["json"] == {"variables": variables}
+
+
+class TestReloadScripts:
+    """Test the reload_scripts function."""
+
+    @pytest.fixture(autouse=True)
+    def mock_config(self):
+        """Mock HA_URL and HA_TOKEN for all tests in this class."""
+        with (
+            patch("app.config.HA_URL", "http://localhost:8123"),
+            patch("app.config.HA_TOKEN", "test_token"),
+            patch("app.core.decorators.HA_TOKEN", "test_token"),
+        ):
+            yield
+
+    @pytest.mark.asyncio
+    async def test_reload_scripts_success(self):
+        """Test successful reload of scripts."""
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {}
+        mock_response.raise_for_status = MagicMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch("app.api.scripts.get_client", return_value=mock_client):
+            result = await reload_scripts()
+
+            assert result == {}
+            mock_client.post.assert_called_once()
+            call_args = mock_client.post.call_args
+            assert call_args[0][0] == "http://localhost:8123/api/services/script/reload"
+            assert call_args[1]["headers"]["Authorization"] == "Bearer test_token"
+            assert call_args[1]["json"] == {}
+
+    @pytest.mark.asyncio
+    async def test_reload_scripts_http_error(self):
+        """Test reload scripts with HTTP error."""
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Not found", request=MagicMock(), response=mock_response
+        )
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch("app.api.scripts.get_client", return_value=mock_client):
+            result = await reload_scripts()
+
+            assert isinstance(result, dict)
+            assert "error" in result


### PR DESCRIPTION
## 📋 Overview

This PR implements Phase 2.3 of the refactoring epic (#28) by extracting the Scripts domain API layer from `hass.py` into a dedicated `app/api/scripts.py` module.

## 🎯 Changes

### Created `app/api/scripts.py`
- **`get_scripts()`**: Get list of all scripts from Home Assistant
- **`get_script_config()`**: Get script configuration (sequence of actions)
- **`run_script()`**: Execute a script with optional variables
- **`reload_scripts()`**: Reload all scripts from configuration

### Updated Files
- **`app/hass.py`**: Re-exports script functions from `api/scripts.py` for backwards compatibility
- **`app/api/__init__.py`**: Includes script functions in module exports
- **`app/hass.py`**: Fixed indentation issues in `summarize_domain` and `get_area_summary` functions

### Tests
- **Created `tests/unit/test_api_scripts.py`**: Comprehensive unit tests (10 tests) covering:
  - Successful script retrieval
  - Error handling
  - Script configuration via config API and fallback to entity state
  - Script execution with and without variables
  - Script reload functionality

## ✅ Validation

- ✅ **All 114 tests passing**
- ✅ **Coverage: 43.86%** (above 40% requirement)
- ✅ **Linting checks pass** (ruff)
- ✅ **Code formatting** (ruff format)
- ✅ **Backwards compatibility maintained** via `hass.py` re-exports

## 🔗 Related To

- Epic: #28
- Issue: #32
- Follows pattern established in: #31 (Automations API)

## 📝 Implementation Notes

- Follows `BaseAPI` pattern established in Phase 2.1
- Replaced `call_service` calls with direct `httpx` requests to avoid circular dependencies
- Script configuration tries config API first, then falls back to entity state
- All functions use `@handle_api_errors` decorator for consistent error handling
- Comprehensive error handling for processing failures

## 📊 Test Results

```
======================== 114 passed in 3.99s =========================
Coverage: 43.86% (Required: 40%)
app/api/scripts.py: 100% coverage
```

Closes #32