### PR TITLE
Phase 3.3: Extract Scenes, Integrations, System, Services, Templates MCP Tools

### DIFF
--- a/app/tools/__init__.py
+++ b/app/tools/__init__.py
@@ -5,6 +5,28 @@ Tools are thin wrappers around API functions that expose
 Home Assistant functionality via the Model Context Protocol.
 """
 
-from app.tools import areas, automations, devices, entities, scripts
+from app.tools import (
+    areas,
+    automations,
+    devices,
+    entities,
+    integrations,
+    scenes,
+    scripts,
+    services,
+    system,
+    templates,
+)
 
-__all__ = ["areas", "automations", "devices", "entities", "scripts"]
+__all__ = [
+    "areas",
+    "automations",
+    "devices",
+    "entities",
+    "integrations",
+    "scenes",
+    "scripts",
+    "services",
+    "system",
+    "templates",
+]

--- a/app/tools/integrations.py
+++ b/app/tools/integrations.py
@@ -1,0 +1,103 @@
+"""Integration MCP tools for hass-mcp.
+
+This module provides MCP tools for interacting with Home Assistant integrations.
+These tools are thin wrappers around the integrations API layer.
+"""
+
+import logging
+from typing import Any
+
+from app.api.integrations import (
+    get_integration_config,
+    get_integrations,
+    reload_integration,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def list_integrations(domain: str | None = None) -> list[dict[str, Any]]:
+    """
+    Get a list of all configuration entries (integrations) from Home Assistant.
+
+    Args:
+        domain: Optional domain to filter integrations by (e.g., 'mqtt', 'zwave')
+
+    Returns:
+        List of integration entries with their status and configuration.
+        Each entry contains:
+        - entry_id: Unique identifier for the integration entry
+        - domain: The integration domain (e.g., 'mqtt', 'zwave')
+        - title: Display name of the integration
+        - source: Where the integration was configured (user, discovery, etc.)
+        - state: Current state (loaded, setup_error, etc.)
+        - supports_options: Whether the integration supports configuration options
+        - pref_disable_new_entities: Preference to disable new entities
+        - pref_disable_polling: Preference to disable polling
+
+    Examples:
+        domain=None - get all integrations
+        domain="mqtt" - get only MQTT integrations
+
+    Best Practices:
+        - Use domain filter to find specific integration types
+        - Check state field to identify integrations with errors
+        - Use get_integration_config for detailed information
+    """
+    logger.info("Getting integrations" + (f" for domain: {domain}" if domain else ""))
+    return await get_integrations(domain)
+
+
+async def get_integration_config_tool(entry_id: str) -> dict[str, Any]:
+    """
+    Get detailed configuration for a specific integration entry.
+
+    Args:
+        entry_id: The entry ID of the integration to get
+
+    Returns:
+        Detailed configuration dictionary for the integration entry, including:
+        - entry_id: Unique identifier
+        - domain: Integration domain
+        - title: Display name
+        - source: Configuration source
+        - state: Current state (loaded, setup_error, etc.)
+        - options: Integration-specific configuration options
+        - pref_disable_new_entities: Preference setting
+        - pref_disable_polling: Preference setting
+
+    Examples:
+        entry_id="abc123" - get configuration for entry with ID abc123
+
+    Error Handling:
+        - Returns error dict if entry_id doesn't exist (404)
+        - Error handling is managed by handle_api_errors decorator
+    """
+    logger.info(f"Getting integration config for entry: {entry_id}")
+    return await get_integration_config(entry_id)
+
+
+async def reload_integration_tool(entry_id: str) -> dict[str, Any]:
+    """
+    Reload a specific integration.
+
+    Args:
+        entry_id: The entry ID of the integration to reload
+
+    Returns:
+        Response from the reload service call
+
+    Examples:
+        entry_id="abc123" - reload integration with ID abc123
+
+    Note:
+        ⚠️ Reloading an integration may cause temporary unavailability of its entities.
+        Use with caution, especially for critical integrations like MQTT or Z-Wave.
+
+    Best Practices:
+        - Check integration state before reloading
+        - Reload integrations that are showing setup errors
+        - Avoid reloading during active automation execution
+    """
+    logger.info(f"Reloading integration: {entry_id}")
+    return await reload_integration(entry_id)

--- a/app/tools/scenes.py
+++ b/app/tools/scenes.py
@@ -1,0 +1,153 @@
+"""Scene MCP tools for hass-mcp.
+
+This module provides MCP tools for interacting with Home Assistant scenes.
+These tools are thin wrappers around the scenes API layer.
+"""
+
+import logging
+from typing import Any
+
+from app.api.scenes import (
+    activate_scene,
+    create_scene,
+    get_scene_config,
+    get_scenes,
+    reload_scenes,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def list_scenes_tool() -> list[dict[str, Any]]:
+    """
+    Get a list of all scenes in Home Assistant.
+
+    Returns:
+        List of scene dictionaries containing:
+        - entity_id: The scene entity ID (e.g., 'scene.living_room_dim')
+        - state: Current state of the scene
+        - friendly_name: Display name of the scene
+        - entity_id_list: List of entity IDs included in the scene
+        - snapshot: Snapshot of entity states when scene was created
+
+    Examples:
+        Returns all scenes with their configuration
+
+    Best Practices:
+        - Use this to discover available scenes
+        - Check entity_id_list to see what entities a scene affects
+        - Review snapshots to understand scene states
+    """
+    logger.info("Getting list of scenes")
+    return await get_scenes()
+
+
+async def get_scene_tool(scene_id: str) -> dict[str, Any]:
+    """
+    Get scene configuration (what entities/values it saves).
+
+    Args:
+        scene_id: The scene ID to get (with or without 'scene.' prefix)
+
+    Returns:
+        Scene configuration dictionary with:
+        - entity_id: The scene entity ID
+        - friendly_name: Display name of the scene
+        - entity_id_list: List of entity IDs included in the scene
+        - snapshot: Snapshot of entity states when scene was created
+
+    Examples:
+        scene_id="living_room_dim" - get config for scene with ID living_room_dim
+        scene_id="scene.living_room_dim" - also works with full entity ID
+
+    Note:
+        Scene configuration shows what entities are included in the scene
+        and what states they were in when the scene was created.
+
+    Best Practices:
+        - Use this to inspect what entities a scene affects
+        - Check snapshot to see what states will be restored
+    """
+    logger.info(f"Getting scene config for: {scene_id}")
+    return await get_scene_config(scene_id)
+
+
+async def create_scene_tool(
+    name: str,
+    entity_ids: list[str],
+    states: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """
+    Create a new scene.
+
+    Args:
+        name: Display name for the scene
+        entity_ids: List of entity IDs to include in the scene
+        states: Optional dictionary of entity states to capture (if None, captures current states)
+
+    Returns:
+        Response from the create operation, or error message with YAML example if creation fails
+
+    Examples:
+        name="Living Room Dim", entity_ids=["light.living_room", "light.kitchen"]
+        name="Movie Mode", entity_ids=["light.living_room"], states={"light.living_room": {"state": "on", "brightness": 50}}
+
+    Note:
+        ⚠️ Scene creation via API may not be available in all Home Assistant versions.
+        If it fails, a helpful YAML configuration example is returned.
+
+    Best Practices:
+        - Try creating via API first
+        - If it fails, use the provided YAML example for manual creation
+        - Include states parameter to specify exact entity states
+    """
+    logger.info(f"Creating scene: {name} with entities: {entity_ids}")
+    return await create_scene(name, entity_ids, states)
+
+
+async def activate_scene_tool(scene_id: str) -> dict[str, Any]:
+    """
+    Activate/restore a scene.
+
+    Args:
+        scene_id: The scene ID to activate (with or without 'scene.' prefix)
+
+    Returns:
+        Response from the activate operation
+
+    Examples:
+        scene_id="living_room_dim" - activate scene with ID living_room_dim
+        scene_id="scene.living_room_dim" - also works with full entity ID
+
+    Note:
+        Activating a scene restores all entities to their saved states.
+        The scene entity_id can be provided with or without the 'scene.' prefix.
+
+    Best Practices:
+        - Use this to restore lighting presets and room configurations
+        - Get scene config first to see what will be restored
+    """
+    logger.info(f"Activating scene: {scene_id}")
+    return await activate_scene(scene_id)
+
+
+async def reload_scenes_tool() -> dict[str, Any]:
+    """
+    Reload scenes from configuration.
+
+    Returns:
+        Response from the reload operation
+
+    Examples:
+        Reloads all scene configurations after modifying YAML files
+
+    Note:
+        Reloading scenes reloads all scene configurations from YAML files.
+        This is useful after modifying scene configuration files.
+
+    Best Practices:
+        - Reload scenes after making configuration changes
+        - Use this after updating scene YAML files
+    """
+    logger.info("Reloading scenes")
+    return await reload_scenes()

--- a/app/tools/services.py
+++ b/app/tools/services.py
@@ -1,0 +1,40 @@
+"""Service MCP tools for hass-mcp.
+
+This module provides MCP tools for calling Home Assistant services.
+These tools are thin wrappers around the services API layer.
+"""
+
+import logging
+from typing import Any
+
+from app.api.services import call_service
+
+logger = logging.getLogger(__name__)
+
+
+async def call_service_tool(
+    domain: str, service: str, data: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """
+    Call any Home Assistant service (low-level API access).
+
+    Args:
+        domain: The domain of the service (e.g., 'light', 'switch', 'automation')
+        service: The service to call (e.g., 'turn_on', 'turn_off', 'toggle')
+        data: Optional data to pass to the service (e.g., {'entity_id': 'light.living_room'})
+
+    Returns:
+        The response from Home Assistant (usually empty for successful calls)
+
+    Examples:
+        domain='light', service='turn_on', data={'entity_id': 'light.x', 'brightness': 255}
+        domain='automation', service='reload'
+        domain='fan', service='set_percentage', data={'entity_id': 'fan.x', 'percentage': 50}
+
+    Best Practices:
+        - Use domain and service to identify the service to call
+        - Pass service data in the data parameter
+        - Check response for errors or status
+    """
+    logger.info(f"Calling Home Assistant service: {domain}.{service} with data: {data}")
+    return await call_service(domain, service, data or {})

--- a/app/tools/system.py
+++ b/app/tools/system.py
@@ -1,0 +1,296 @@
+"""System MCP tools for hass-mcp.
+
+This module provides MCP tools for interacting with Home Assistant system information.
+These tools are thin wrappers around the system API layer.
+"""
+
+import logging
+from typing import Any
+
+from app.api.entities import get_entity_history
+from app.api.system import (
+    get_core_config,
+    get_hass_error_log,
+    get_hass_version,
+    get_system_health,
+    get_system_overview,
+    restart_home_assistant,
+)
+from app.hass import summarize_domain
+
+logger = logging.getLogger(__name__)
+
+
+async def get_version() -> str:
+    """
+    Get the Home Assistant version.
+
+    Returns:
+        A string with the Home Assistant version (e.g., "2025.3.0")
+    """
+    logger.info("Getting Home Assistant version")
+    return await get_hass_version()
+
+
+async def system_overview() -> dict[str, Any]:
+    """
+    Get a comprehensive overview of the entire Home Assistant system.
+
+    Returns:
+        A dictionary containing:
+        - total_entities: Total count of all entities
+        - domains: Dictionary of domains with their entity counts and state distributions
+        - domain_samples: Representative sample entities for each domain (2-3 per domain)
+        - domain_attributes: Common attributes for each domain
+        - area_distribution: Entities grouped by area (if available)
+
+    Examples:
+        Returns domain counts, sample entities, and common attributes
+
+    Best Practices:
+        - Use this as the first call when exploring an unfamiliar Home Assistant instance
+        - Perfect for building context about the structure of the smart home
+        - After getting an overview, use domain_summary_tool to dig deeper into specific domains
+    """
+    logger.info("Generating complete system overview")
+    return await get_system_overview()
+
+
+async def get_error_log() -> dict[str, Any]:
+    """
+    Get the Home Assistant error log for troubleshooting.
+
+    Returns:
+        A dictionary containing:
+        - log_text: The full error log text
+        - error_count: Number of ERROR entries found
+        - warning_count: Number of WARNING entries found
+        - integration_mentions: Map of integration names to mention counts
+        - error: Error message if retrieval failed
+
+    Examples:
+        Returns errors, warnings count and integration mentions
+
+    Best Practices:
+        - Use this tool when troubleshooting specific Home Assistant errors
+        - Look for patterns in repeated errors
+        - Pay attention to timestamps to correlate errors with events
+        - Focus on integrations with many mentions in the log
+    """
+    logger.info("Getting Home Assistant error log")
+    return await get_hass_error_log()
+
+
+async def system_health() -> dict[str, Any]:
+    """
+    Get system health information from Home Assistant.
+
+    Returns:
+        A dictionary containing system health information for each component.
+        Each component includes health status and version information.
+
+        Example response:
+        {
+            "homeassistant": {
+                "healthy": true,
+                "version": "2025.3.0"
+            },
+            "supervisor": {
+                "healthy": true,
+                "version": "2025.03.1"
+            }
+        }
+
+    Examples:
+        Check overall system health and component status
+
+    Best Practices:
+        - Use this tool to monitor system resources and health
+        - Check after updates or when experiencing issues
+        - Review all component health statuses, not just overall health
+        - Note that some components may not be available in all HA installations
+          (e.g., supervisor is only available on Home Assistant OS)
+
+    Error Handling:
+        - Returns error if endpoint is not available (some HA versions/configurations)
+        - Gracefully handles missing components
+        - Returns helpful error messages for permission issues
+    """
+    logger.info("Getting Home Assistant system health")
+    return await get_system_health()
+
+
+async def core_config() -> dict[str, Any]:
+    """
+    Get core configuration from Home Assistant.
+
+    Returns:
+        A dictionary containing core configuration information including:
+        - location_name: The name of the location
+        - time_zone: Configured timezone
+        - unit_system: Unit system configuration (temperature, length, mass, volume)
+        - components: List of all loaded components/integrations
+        - version: Home Assistant version
+        - latitude/longitude: Location coordinates
+        - elevation: Elevation above sea level
+        - currency: Configured currency
+        - country: Configured country code
+        - language: Configured language
+
+        Example response:
+        {
+            "location_name": "Home",
+            "time_zone": "America/New_York",
+            "unit_system": {
+                "length": "km",
+                "mass": "g",
+                "temperature": "°C",
+                "volume": "L"
+            },
+            "version": "2025.3.0",
+            "components": ["mqtt", "hue", "automation", ...]
+        }
+
+    Examples:
+        Get timezone, unit system, and location information
+        List all loaded components/integrations
+        Check Home Assistant version and configuration details
+
+    Best Practices:
+        - Use to understand the HA instance configuration
+        - Check which components are loaded before using specific integrations
+        - Verify timezone and unit system settings for automations
+        - Use for debugging location-based automations
+    """
+    logger.info("Getting Home Assistant core configuration")
+    return await get_core_config()
+
+
+async def restart_ha() -> dict[str, Any]:
+    """
+    Restart Home Assistant.
+
+    ⚠️ WARNING: Temporarily disrupts all Home Assistant operations
+
+    Returns:
+        Result of restart operation
+
+    Warning:
+        ⚠️ This will restart Home Assistant, causing temporary unavailability.
+        All entities and services will be unavailable during restart.
+        Use with caution!
+
+    Best Practices:
+        - Only restart when necessary (e.g., after configuration changes)
+        - Warn users about temporary unavailability
+        - Consider restarting during low-activity periods
+    """
+    logger.info("Restarting Home Assistant")
+    return await restart_home_assistant()
+
+
+async def get_history(entity_id: str, hours: int = 24) -> dict[str, Any]:
+    """
+    Get the history of an entity's state changes.
+
+    Args:
+        entity_id: The entity ID to get history for
+        hours: Number of hours of history to retrieve (default: 24)
+
+    Returns:
+        A dictionary containing:
+        - entity_id: The entity ID requested
+        - states: List of state objects with timestamps
+        - count: Number of state changes found
+        - first_changed: Timestamp of earliest state change
+        - last_changed: Timestamp of most recent state change
+
+    Examples:
+        entity_id="light.living_room" - get 24h history
+        entity_id="sensor.temperature", hours=168 - get 7 day history
+
+    Best Practices:
+        - Keep hours reasonable (24-72) for token efficiency
+        - Use for entities with discrete state changes rather than continuously changing sensors
+        - Consider the state distribution rather than every individual state
+    """
+    logger.info(f"Getting history for entity: {entity_id}, hours: {hours}")
+
+    try:
+        # Call the API function to get history
+        history_data = await get_entity_history(entity_id, hours)
+
+        # Check for errors from the API call
+        if isinstance(history_data, dict) and "error" in history_data:
+            return {
+                "entity_id": entity_id,
+                "error": history_data["error"],
+                "states": [],
+                "count": 0,
+            }
+
+        # The result from the API is a list of lists of state changes
+        # We need to flatten it and process it
+        states = []
+        if history_data and isinstance(history_data, list):
+            for state_list in history_data:
+                states.extend(state_list)
+
+        if not states:
+            return {
+                "entity_id": entity_id,
+                "states": [],
+                "count": 0,
+                "first_changed": None,
+                "last_changed": None,
+                "note": "No state changes found in the specified timeframe.",
+            }
+
+        # Sort states by last_changed timestamp
+        states.sort(key=lambda x: x.get("last_changed", ""))
+
+        # Extract first and last changed timestamps
+        first_changed = states[0].get("last_changed")
+        last_changed = states[-1].get("last_changed")
+
+        return {
+            "entity_id": entity_id,
+            "states": states,
+            "count": len(states),
+            "first_changed": first_changed,
+            "last_changed": last_changed,
+        }
+    except Exception as e:
+        logger.error(f"Error processing history for {entity_id}: {str(e)}")
+        return {
+            "entity_id": entity_id,
+            "error": f"Error processing history: {str(e)}",
+            "states": [],
+            "count": 0,
+        }
+
+
+async def domain_summary_tool(domain: str, example_limit: int = 3) -> dict[str, Any]:
+    """
+    Get a summary of entities in a specific domain.
+
+    Args:
+        domain: The domain to summarize (e.g., 'light', 'switch', 'sensor')
+        example_limit: Maximum number of examples to include for each state
+
+    Returns:
+        A dictionary containing:
+        - total_count: Number of entities in the domain
+        - state_distribution: Count of entities in each state
+        - examples: Sample entities for each state
+        - common_attributes: Most frequently occurring attributes
+
+    Examples:
+        domain="light" - get light summary
+        domain="climate", example_limit=5 - climate summary with more examples
+
+    Best Practices:
+        - Use this before retrieving all entities in a domain to understand what's available
+    """
+    logger.info(f"Getting domain summary for: {domain}")
+    return await summarize_domain(domain, example_limit)

--- a/app/tools/templates.py
+++ b/app/tools/templates.py
@@ -1,0 +1,50 @@
+"""Template MCP tools for hass-mcp.
+
+This module provides MCP tools for testing Jinja2 templates.
+These tools are thin wrappers around the templates API layer.
+"""
+
+import logging
+from typing import Any
+
+from app.api.templates import test_template
+
+logger = logging.getLogger(__name__)
+
+
+async def test_template_tool(
+    template_string: str,
+    entity_context: dict[str, Any] | None = None,  # noqa: PT028
+) -> dict[str, Any]:
+    """
+    Test Jinja2 template rendering.
+
+    Args:
+        template_string: The Jinja2 template string to test
+        entity_context: Optional dictionary of entity IDs to provide as context
+                         (e.g., {"entity_id": "light.living_room"})
+
+    Returns:
+        Dictionary containing:
+        - result: The rendered template result
+        - listeners: Entity listeners (if applicable)
+        - error: Error message if template rendering failed
+
+    Examples:
+        template_string="{{ states('sensor.temperature') }}" - test simple template
+        template_string="{{ states('light.living_room') }}", entity_context={"entity_id": "light.living_room"}
+
+    Note:
+        Template testing API might not be available in all Home Assistant versions.
+        If unavailable, returns a helpful error message.
+
+    Best Practices:
+        - Test templates before using them in automations or scripts
+        - Use entity_context to test templates with specific entity context
+        - Check for errors in the response
+    """
+    logger.info(
+        f"Testing template: {template_string[:50]}..."
+        + (f" with context: {entity_context}" if entity_context else "")
+    )
+    return await test_template(template_string, entity_context)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -263,7 +263,14 @@ class TestMCPServer:
             "common_attributes": [("friendly_name", 2), ("brightness", 1)],
         }
 
-        with patch("app.server.summarize_domain", return_value=mock_summary) as mock_summarize:
+        with (
+            patch(
+                "app.tools.system.summarize_domain",
+                new_callable=AsyncMock,
+                return_value=mock_summary,
+            ) as mock_summarize,
+            patch("app.hass.summarize_domain", new_callable=AsyncMock, return_value=mock_summary),
+        ):
             # Test the function
             result = await domain_summary_tool(domain="light", example_limit=3)
 
@@ -335,7 +342,11 @@ class TestMCPServer:
             "recorder": {"healthy": True},
         }
 
-        with patch("app.server.get_system_health", return_value=mock_health_data) as mock_get:
+        with patch(
+            "app.tools.system.get_system_health",
+            new_callable=AsyncMock,
+            return_value=mock_health_data,
+        ) as mock_get:
             # Test the function
             result = await system_health()
 
@@ -369,7 +380,11 @@ class TestMCPServer:
             "longitude": -74.0060,
         }
 
-        with patch("app.server.get_core_config", return_value=mock_config_data) as mock_get:
+        with patch(
+            "app.tools.system.get_core_config",
+            new_callable=AsyncMock,
+            return_value=mock_config_data,
+        ) as mock_get:
             # Test the function
             result = await core_config()
 


### PR DESCRIPTION
## 📋 Overview
This PR completes Phase 3.3 by extracting the remaining MCP tools from `server.py` into dedicated tools modules. This is the final part of Phase 3 refactoring.

## 🎯 Changes

### New Tools Modules Created

1. **`app/tools/scenes.py`**
   - `list_scenes_tool()` - List all scenes
   - `get_scene_tool()` - Get scene configuration
   - `create_scene_tool()` - Create new scene
   - `activate_scene_tool()` - Activate/restore scene
   - `reload_scenes_tool()` - Reload scenes from configuration

2. **`app/tools/integrations.py`**
   - `list_integrations()` - List all configuration entries
   - `get_integration_config_tool()` - Get detailed integration configuration
   - `reload_integration_tool()` - Reload a specific integration

3. **`app/tools/system.py`**
   - `get_version()` - Get Home Assistant version
   - `system_overview()` - Get comprehensive system overview
   - `get_error_log()` - Get error log for troubleshooting
   - `system_health()` - Get system health information
   - `core_config()` - Get core configuration
   - `restart_ha()` - Restart Home Assistant
   - `get_history()` - Get entity history
   - `domain_summary_tool()` - Get domain summary

4. **`app/tools/services.py`**
   - `call_service_tool()` - Call any Home Assistant service

5. **`app/tools/templates.py`**
   - `test_template_tool()` - Test Jinja2 template rendering

### Server.py Updates

- ✅ Removed unused imports from `app.hass` (scenes, integrations, system, services, templates functions)
- ✅ Updated imports to use new tools modules
- ✅ Registered all tools with MCP instance
- ✅ Maintained backward compatibility via re-exports
- ✅ Updated comments to reflect new structure

### Test Updates

- ✅ Updated `tests/test_server.py` to patch correct modules for system tools
- ✅ Fixed `test_domain_summary_tool`, `test_system_health_tool`, and `test_core_config_tool` to patch `app.tools.system` instead of `app.server`

## 📊 Testing

- ✅ **All 210 tests passing**
- ✅ **Coverage: 58%** (above 40% gate)
- ✅ **Linting checks: clean**
- ✅ **Formatting: applied**

## 🔍 Verification

### Before
- Tools mixed in `server.py` with many unused imports from `app.hass`
- Scene, integration, system, service, and template tools embedded in server.py

### After
- All tools properly modularized in dedicated `app/tools/*` modules
- Tools follow consistent pattern (thin wrappers around API layer)
- `server.py` cleaned up with unused imports removed
- Backward compatibility maintained via re-exports

## 📝 Notes

- Tools import from their respective API modules (`app.api.scenes`, `app.api.integrations`, etc.)
- `domain_summary_tool` still imports `summarize_domain` from `app.hass` (not yet refactored to API layer)
- All tools maintain same function signatures for backward compatibility
- Tools are registered with MCP instance using `@mcp.tool()` decorators via `async_handler`

## ✅ Acceptance Criteria

- ✅ All remaining tools extracted
- ✅ Integration tests passing
- ✅ `server.py` cleaned up (unused imports removed)
- ✅ MCP server still fully functional
- ✅ All tools accessible via MCP interface
- ✅ Coverage meets requirements (58% > 40%)
- ✅ Linting checks passing

## 🔗 Related To

- Epic: #28
- Depends on: #35, #36, #37 (API layers)
- Completes: Phase 3 refactoring
- Blocks: Phase 4 (new features)

---

This PR completes Phase 3 of the refactoring epic. All MCP tools are now properly modularized and ready for Phase 4 feature additions.