### PR TITLE
Phase 4.4: Add Blueprints Management Tools

### DIFF
--- a/app/api/blueprints.py
+++ b/app/api/blueprints.py
@@ -1,0 +1,213 @@
+"""Blueprints API module for hass-mcp.
+
+This module provides functions for interacting with Home Assistant blueprints.
+Blueprints are reusable automation templates.
+"""
+
+import logging
+import urllib.parse
+import uuid
+from typing import Any
+
+from app.api.automations import create_automation
+from app.api.base import BaseAPI
+from app.core.decorators import handle_api_errors
+
+logger = logging.getLogger(__name__)
+
+
+class BlueprintsAPI(BaseAPI):
+    """API client for Home Assistant blueprint operations."""
+
+    pass
+
+
+_blueprints_api = BlueprintsAPI()
+
+
+@handle_api_errors
+async def list_blueprints(domain: str | None = None) -> list[dict[str, Any]]:
+    """
+    Get list of available blueprints.
+
+    Args:
+        domain: Optional domain to filter blueprints by (e.g., 'automation')
+
+    Returns:
+        List of blueprint dictionaries containing:
+        - path: Blueprint path
+        - domain: Blueprint domain
+        - name: Blueprint name
+        - metadata: Blueprint metadata
+
+    Example response:
+        [
+            {
+                "path": "blueprint_path",
+                "domain": "automation",
+                "name": "Blueprint Name",
+                "metadata": {...}
+            }
+        ]
+
+    Note:
+        Blueprints are reusable automation templates.
+        If domain is provided, returns blueprints for that domain only.
+
+    Best Practices:
+        - Use domain filter to find blueprints for specific use cases
+        - Check blueprint metadata to understand what inputs are required
+        - Use get_blueprint() to get full blueprint definition before using
+    """
+    url = f"/api/blueprint/domain/{domain}" if domain else "/api/blueprint/list"
+    return await _blueprints_api.get(url)
+
+
+@handle_api_errors
+async def get_blueprint(blueprint_id: str, domain: str | None = None) -> dict[str, Any]:
+    """
+    Get blueprint definition and metadata.
+
+    Args:
+        blueprint_id: The blueprint ID to get (may include domain and path)
+        domain: Optional domain for the blueprint (e.g., 'automation')
+
+    Returns:
+        Blueprint definition dictionary with:
+        - path: Blueprint path
+        - domain: Blueprint domain
+        - name: Blueprint name
+        - metadata: Blueprint metadata including inputs, description
+        - definition: Blueprint YAML definition
+
+    Example response:
+        {
+            "path": "blueprint_path",
+            "domain": "automation",
+            "name": "Blueprint Name",
+            "metadata": {
+                "input": {...},
+                "description": "..."
+            },
+            "definition": "..."
+        }
+
+    Note:
+        Blueprint ID typically includes domain and path.
+        If domain is not provided, attempts to extract it from blueprint_id.
+
+    Best Practices:
+        - Use this to inspect blueprint inputs before creating automation
+        - Check metadata to understand what the blueprint does
+        - Review definition to understand blueprint structure
+    """
+    # Blueprint ID typically includes domain and path
+    if domain:
+        url = f"/api/blueprint/metadata/{domain}/{blueprint_id}"
+    else:
+        # Try to extract domain from blueprint_id
+        parts = blueprint_id.split("/")
+        if len(parts) >= 2:
+            domain = parts[0]
+            path = "/".join(parts[1:])
+            url = f"/api/blueprint/metadata/{domain}/{path}"
+        else:
+            return {
+                "error": "Cannot determine domain for blueprint. Please provide domain parameter."
+            }
+
+    return await _blueprints_api.get(url)
+
+
+@handle_api_errors
+async def import_blueprint(url: str) -> dict[str, Any]:
+    """
+    Import blueprint from URL.
+
+    Args:
+        url: The URL to import the blueprint from
+
+    Returns:
+        Response dictionary containing imported blueprint information
+
+    Example response:
+        {
+            "status": "imported",
+            "blueprint": {...}
+        }
+
+    Note:
+        This imports a blueprint from a community URL or external source.
+        The URL is URL-encoded when making the API request.
+
+    Best Practices:
+        - Use community blueprint URLs from Home Assistant documentation
+        - Verify blueprint source before importing
+        - Check blueprint definition after import before using
+    """
+    # URL encode the blueprint URL
+    encoded_url = urllib.parse.quote(url, safe="")
+
+    endpoint = f"/api/blueprint/import/{encoded_url}"
+    return await _blueprints_api.get(endpoint)
+
+
+@handle_api_errors
+async def create_automation_from_blueprint(
+    blueprint_id: str, inputs: dict[str, Any], domain: str | None = None
+) -> dict[str, Any]:
+    """
+    Create automation from blueprint with specified inputs.
+
+    Args:
+        blueprint_id: The blueprint ID to use (may include domain and path)
+        inputs: Dictionary of input values for the blueprint (must match blueprint input schema)
+        domain: Optional domain for the blueprint (e.g., 'automation')
+
+    Returns:
+        Response from the automation creation operation
+
+    Example response:
+        {
+            "automation_id": "automation_12345",
+            "status": "created"
+        }
+
+    Note:
+        This creates a new automation using a blueprint as a template.
+        The inputs dictionary must match the blueprint's input schema.
+        An automation ID will be automatically generated if not provided in inputs.
+
+    Best Practices:
+        - Get blueprint definition first to see required inputs
+        - Validate inputs match blueprint schema
+        - Use descriptive automation_id in inputs for better organization
+    """
+    # Get blueprint definition first
+    blueprint = await get_blueprint(blueprint_id, domain)
+
+    # Check for errors
+    if isinstance(blueprint, dict) and "error" in blueprint:
+        return blueprint
+
+    # Construct automation config from blueprint
+    # Extract domain from blueprint if not provided
+    if not domain:
+        domain = blueprint.get("domain", "automation")
+
+    # Construct automation config with blueprint reference
+    automation_config: dict[str, Any] = {
+        "use_blueprint": {
+            "path": blueprint.get("path", blueprint_id),
+            "input": inputs,
+        }
+    }
+
+    # Generate automation_id if not provided in inputs
+    automation_id = inputs.get("automation_id")
+    if not automation_id:
+        automation_id = f"automation_{uuid.uuid4().hex[:8]}"
+        automation_config["id"] = automation_id
+
+    # Use the create_automation function
+    return await create_automation(automation_config)

--- a/app/tools/__init__.py
+++ b/app/tools/__init__.py
@@ -8,6 +8,7 @@ Home Assistant functionality via the Model Context Protocol.
 from app.tools import (
     areas,
     automations,
+    blueprints,
     devices,
     diagnostics,
     entities,
@@ -24,6 +25,7 @@ from app.tools import (
 __all__ = [
     "areas",
     "automations",
+    "blueprints",
     "devices",
     "diagnostics",
     "entities",

--- a/app/tools/blueprints.py
+++ b/app/tools/blueprints.py
@@ -1,0 +1,147 @@
+"""Blueprints MCP tools for hass-mcp.
+
+This module provides MCP tools for interacting with Home Assistant blueprints.
+These tools are thin wrappers around the blueprints API layer.
+"""
+
+import logging
+from typing import Any
+
+from app.api.blueprints import (
+    create_automation_from_blueprint,
+    get_blueprint,
+    import_blueprint,
+    list_blueprints,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def list_blueprints_tool(domain: str | None = None) -> list[dict[str, Any]]:
+    """
+    Get a list of all available blueprints, optionally filtered by domain.
+
+    Args:
+        domain: Optional domain to filter blueprints by (e.g., 'automation')
+
+    Returns:
+        List of blueprint dictionaries containing:
+        - path: Blueprint path
+        - domain: Blueprint domain
+        - name: Blueprint name
+        - metadata: Blueprint metadata
+
+    Examples:
+        domain=None - get all blueprints
+        domain="automation" - get only automation blueprints
+
+    Note:
+        Blueprints are reusable automation templates.
+        Use domain filter to find blueprints for specific use cases.
+
+    Best Practices:
+        - Use domain filter to find blueprints for specific use cases
+        - Check blueprint metadata to understand what inputs are required
+        - Use get_blueprint to get full blueprint definition before using
+        - Verify blueprint source before using in production
+    """
+    logger.info("Getting blueprints" + (f" for domain: {domain}" if domain else ""))
+    return await list_blueprints(domain)
+
+
+async def get_blueprint_tool(blueprint_id: str, domain: str | None = None) -> dict[str, Any]:
+    """
+    Get blueprint definition and metadata.
+
+    Args:
+        blueprint_id: The blueprint ID to get (may include domain and path)
+        domain: Optional domain for the blueprint (e.g., 'automation')
+
+    Returns:
+        Blueprint definition dictionary with:
+        - path: Blueprint path
+        - domain: Blueprint domain
+        - name: Blueprint name
+        - metadata: Blueprint metadata including inputs, description
+        - definition: Blueprint YAML definition
+
+    Examples:
+        blueprint_id="motion_light", domain="automation" - get automation blueprint
+        blueprint_id="automation/motion_light" - get blueprint with full path
+
+    Note:
+        Blueprint ID typically includes domain and path.
+        If domain is not provided, attempts to extract it from blueprint_id.
+
+    Best Practices:
+        - Use this to inspect blueprint inputs before creating automation
+        - Check metadata to understand what the blueprint does
+        - Review definition to understand blueprint structure
+        - Validate inputs match blueprint schema before using
+    """
+    logger.info(f"Getting blueprint: {blueprint_id}" + (f" for domain: {domain}" if domain else ""))
+    return await get_blueprint(blueprint_id, domain)
+
+
+async def import_blueprint_tool(url: str) -> dict[str, Any]:
+    """
+    Import blueprint from URL.
+
+    Args:
+        url: The URL to import the blueprint from
+
+    Returns:
+        Response dictionary containing imported blueprint information
+
+    Examples:
+        url="https://www.home-assistant.io/blueprints/..." - import from community
+        url="https://github.com/user/repo/blob/main/blueprint.yaml" - import from GitHub
+
+    Note:
+        This imports a blueprint from a community URL or external source.
+        The URL is automatically URL-encoded when making the API request.
+
+    Best Practices:
+        - Use community blueprint URLs from Home Assistant documentation
+        - Verify blueprint source before importing
+        - Check blueprint definition after import before using
+        - Review blueprint inputs and requirements before creating automations
+    """
+    logger.info(f"Importing blueprint from URL: {url}")
+    return await import_blueprint(url)
+
+
+async def create_automation_from_blueprint_tool(
+    blueprint_id: str, inputs: dict[str, Any], domain: str | None = None
+) -> dict[str, Any]:
+    """
+    Create automation from blueprint with specified inputs.
+
+    Args:
+        blueprint_id: The blueprint ID to use (may include domain and path)
+        inputs: Dictionary of input values for the blueprint (must match blueprint input schema)
+        domain: Optional domain for the blueprint (e.g., 'automation')
+
+    Returns:
+        Response from the automation creation operation
+
+    Examples:
+        blueprint_id="motion_light", domain="automation", inputs={
+            "motion_entity": "binary_sensor.motion",
+            "light_entity": "light.living_room",
+            "delay": "00:00:05"
+        }
+
+    Note:
+        This creates a new automation using a blueprint as a template.
+        The inputs dictionary must match the blueprint's input schema.
+        An automation ID will be automatically generated if not provided in inputs.
+
+    Best Practices:
+        - Get blueprint definition first to see required inputs
+        - Validate inputs match blueprint schema
+        - Use descriptive automation_id in inputs for better organization
+        - Test blueprint automation before using in production
+    """
+    logger.info(f"Creating automation from blueprint: {blueprint_id}")
+    return await create_automation_from_blueprint(blueprint_id, inputs, domain)

--- a/tests/unit/test_api_blueprints.py
+++ b/tests/unit/test_api_blueprints.py
@@ -1,0 +1,431 @@
+"""Unit tests for app.api.blueprints module."""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from app.api.blueprints import (
+    create_automation_from_blueprint,
+    get_blueprint,
+    import_blueprint,
+    list_blueprints,
+)
+
+
+class TestListBlueprints:
+    """Test the list_blueprints function."""
+
+    @pytest.fixture(autouse=True)
+    def mock_config(self):
+        """Mock HA_URL and HA_TOKEN for all tests in this class."""
+        with (
+            patch("app.config.HA_URL", "http://localhost:8123"),
+            patch("app.config.HA_TOKEN", "test_token"),
+            patch("app.core.decorators.HA_TOKEN", "test_token"),
+        ):
+            yield
+
+    @pytest.mark.asyncio
+    async def test_list_blueprints_success_all(self):
+        """Test successful retrieval of all blueprints."""
+        mock_blueprints = [
+            {
+                "path": "motion_light",
+                "domain": "automation",
+                "name": "Motion Light",
+                "metadata": {"description": "Turn on light when motion detected"},
+            },
+            {
+                "path": "presence_detection",
+                "domain": "automation",
+                "name": "Presence Detection",
+                "metadata": {"description": "Detect presence"},
+            },
+        ]
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = mock_blueprints
+
+        with patch("app.api.blueprints._blueprints_api.get", return_value=mock_blueprints):
+            result = await list_blueprints()
+
+            assert isinstance(result, list)
+            assert len(result) == 2
+            assert result[0]["path"] == "motion_light"
+            assert result[1]["path"] == "presence_detection"
+
+    @pytest.mark.asyncio
+    async def test_list_blueprints_success_filtered_by_domain(self):
+        """Test successful retrieval of blueprints filtered by domain."""
+        mock_blueprints = [
+            {
+                "path": "motion_light",
+                "domain": "automation",
+                "name": "Motion Light",
+                "metadata": {"description": "Turn on light when motion detected"},
+            }
+        ]
+
+        with patch("app.api.blueprints._blueprints_api.get", return_value=mock_blueprints):
+            result = await list_blueprints(domain="automation")
+
+            assert isinstance(result, list)
+            assert len(result) == 1
+            assert result[0]["domain"] == "automation"
+
+    @pytest.mark.asyncio
+    async def test_list_blueprints_empty_result(self):
+        """Test empty result when no blueprints available."""
+        with patch("app.api.blueprints._blueprints_api.get", return_value=[]):
+            result = await list_blueprints()
+
+            assert isinstance(result, list)
+            assert len(result) == 0
+
+    @pytest.mark.asyncio
+    async def test_list_blueprints_http_error(self):
+        """Test HTTP error handling."""
+        with patch(
+            "app.api.blueprints._blueprints_api.get",
+            side_effect=httpx.HTTPStatusError(
+                "404 Not Found",
+                request=MagicMock(),
+                response=MagicMock(status_code=404),
+            ),
+        ):
+            result = await list_blueprints()
+
+            # Error handler wraps list-returning functions in a list
+            assert isinstance(result, list)
+            assert len(result) == 1
+            assert isinstance(result[0], dict)
+            assert "error" in result[0]
+            assert "404" in result[0]["error"]
+
+
+class TestGetBlueprint:
+    """Test the get_blueprint function."""
+
+    @pytest.fixture(autouse=True)
+    def mock_config(self):
+        """Mock HA_URL and HA_TOKEN for all tests in this class."""
+        with (
+            patch("app.config.HA_URL", "http://localhost:8123"),
+            patch("app.config.HA_TOKEN", "test_token"),
+            patch("app.core.decorators.HA_TOKEN", "test_token"),
+        ):
+            yield
+
+    @pytest.mark.asyncio
+    async def test_get_blueprint_success_with_domain(self):
+        """Test successful retrieval of blueprint with domain specified."""
+        mock_blueprint = {
+            "path": "motion_light",
+            "domain": "automation",
+            "name": "Motion Light",
+            "metadata": {
+                "input": {
+                    "motion_entity": {"selector": {"entity": {"domain": "binary_sensor"}}},
+                    "light_entity": {"selector": {"entity": {"domain": "light"}}},
+                },
+                "description": "Turn on light when motion detected",
+            },
+            "definition": "blueprint:\n  name: Motion Light\n  ...",
+        }
+
+        with patch("app.api.blueprints._blueprints_api.get", return_value=mock_blueprint):
+            result = await get_blueprint("motion_light", domain="automation")
+
+            assert isinstance(result, dict)
+            assert result["path"] == "motion_light"
+            assert result["domain"] == "automation"
+            assert "metadata" in result
+            assert "definition" in result
+
+    @pytest.mark.asyncio
+    async def test_get_blueprint_success_with_path(self):
+        """Test successful retrieval of blueprint with full path."""
+        mock_blueprint = {
+            "path": "motion_light",
+            "domain": "automation",
+            "name": "Motion Light",
+            "metadata": {"input": {}, "description": "Turn on light when motion detected"},
+            "definition": "blueprint:\n  name: Motion Light\n  ...",
+        }
+
+        with patch("app.api.blueprints._blueprints_api.get", return_value=mock_blueprint):
+            result = await get_blueprint("automation/motion_light")
+
+            assert isinstance(result, dict)
+            assert result["path"] == "motion_light"
+            assert result["domain"] == "automation"
+
+    @pytest.mark.asyncio
+    async def test_get_blueprint_error_no_domain(self):
+        """Test error when domain cannot be determined."""
+        result = await get_blueprint("motion_light")
+
+        assert isinstance(result, dict)
+        assert "error" in result
+        assert "domain" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_get_blueprint_http_error(self):
+        """Test HTTP error handling."""
+        with patch(
+            "app.api.blueprints._blueprints_api.get",
+            side_effect=httpx.HTTPStatusError(
+                "404 Not Found",
+                request=MagicMock(),
+                response=MagicMock(status_code=404),
+            ),
+        ):
+            result = await get_blueprint("nonexistent", domain="automation")
+
+            assert isinstance(result, dict)
+            assert "error" in result
+            assert "404" in result["error"]
+
+
+class TestImportBlueprint:
+    """Test the import_blueprint function."""
+
+    @pytest.fixture(autouse=True)
+    def mock_config(self):
+        """Mock HA_URL and HA_TOKEN for all tests in this class."""
+        with (
+            patch("app.config.HA_URL", "http://localhost:8123"),
+            patch("app.config.HA_TOKEN", "test_token"),
+            patch("app.core.decorators.HA_TOKEN", "test_token"),
+        ):
+            yield
+
+    @pytest.mark.asyncio
+    async def test_import_blueprint_success(self):
+        """Test successful blueprint import."""
+        mock_response = {
+            "status": "imported",
+            "blueprint": {
+                "path": "motion_light",
+                "domain": "automation",
+                "name": "Motion Light",
+            },
+        }
+
+        with patch("app.api.blueprints._blueprints_api.get", return_value=mock_response):
+            result = await import_blueprint("https://www.home-assistant.io/blueprints/example.yaml")
+
+            assert isinstance(result, dict)
+            assert result["status"] == "imported"
+            assert "blueprint" in result
+
+    @pytest.mark.asyncio
+    async def test_import_blueprint_url_encoding(self):
+        """Test that URL is properly encoded."""
+        test_url = "https://github.com/user/repo/blob/main/blueprint.yaml?token=abc123"
+        mock_response = {"status": "imported"}
+
+        with patch(
+            "app.api.blueprints._blueprints_api.get", return_value=mock_response
+        ) as mock_get:
+            await import_blueprint(test_url)
+
+            # Verify that get was called with encoded URL
+            call_args = mock_get.call_args
+            assert call_args is not None
+            # The endpoint should contain the encoded URL
+            endpoint = call_args[0][0]
+            assert "/api/blueprint/import/" in endpoint
+
+    @pytest.mark.asyncio
+    async def test_import_blueprint_http_error(self):
+        """Test HTTP error handling."""
+        with patch(
+            "app.api.blueprints._blueprints_api.get",
+            side_effect=httpx.HTTPStatusError(
+                "400 Bad Request",
+                request=MagicMock(),
+                response=MagicMock(status_code=400),
+            ),
+        ):
+            result = await import_blueprint("https://invalid-url.com/blueprint.yaml")
+
+            assert isinstance(result, dict)
+            assert "error" in result
+            assert "400" in result["error"]
+
+
+class TestCreateAutomationFromBlueprint:
+    """Test the create_automation_from_blueprint function."""
+
+    @pytest.fixture(autouse=True)
+    def mock_config(self):
+        """Mock HA_URL and HA_TOKEN for all tests in this class."""
+        with (
+            patch("app.config.HA_URL", "http://localhost:8123"),
+            patch("app.config.HA_TOKEN", "test_token"),
+            patch("app.core.decorators.HA_TOKEN", "test_token"),
+        ):
+            yield
+
+    @pytest.mark.asyncio
+    async def test_create_automation_from_blueprint_success(self):
+        """Test successful automation creation from blueprint."""
+        mock_blueprint = {
+            "path": "motion_light",
+            "domain": "automation",
+            "name": "Motion Light",
+            "metadata": {
+                "input": {
+                    "motion_entity": {"selector": {"entity": {"domain": "binary_sensor"}}},
+                    "light_entity": {"selector": {"entity": {"domain": "light"}}},
+                }
+            },
+        }
+
+        mock_automation_response = {
+            "automation_id": "automation_12345",
+            "status": "created",
+        }
+
+        with (
+            patch("app.api.blueprints.get_blueprint", return_value=mock_blueprint),
+            patch("app.api.blueprints.create_automation", return_value=mock_automation_response),
+        ):
+            result = await create_automation_from_blueprint(
+                "motion_light",
+                inputs={
+                    "motion_entity": "binary_sensor.motion",
+                    "light_entity": "light.living_room",
+                },
+                domain="automation",
+            )
+
+            assert isinstance(result, dict)
+            assert result["automation_id"] == "automation_12345"
+            assert result["status"] == "created"
+
+    @pytest.mark.asyncio
+    async def test_create_automation_from_blueprint_with_automation_id(self):
+        """Test automation creation with provided automation_id."""
+        mock_blueprint = {
+            "path": "motion_light",
+            "domain": "automation",
+            "name": "Motion Light",
+            "metadata": {"input": {}},
+        }
+
+        mock_automation_response = {
+            "automation_id": "custom_automation_id",
+            "status": "created",
+        }
+
+        with (
+            patch("app.api.blueprints.get_blueprint", return_value=mock_blueprint),
+            patch("app.api.blueprints.create_automation", return_value=mock_automation_response),
+        ):
+            result = await create_automation_from_blueprint(
+                "motion_light",
+                inputs={
+                    "automation_id": "custom_automation_id",
+                    "motion_entity": "binary_sensor.motion",
+                },
+                domain="automation",
+            )
+
+            assert isinstance(result, dict)
+            assert result["automation_id"] == "custom_automation_id"
+
+    @pytest.mark.asyncio
+    async def test_create_automation_from_blueprint_blueprint_error(self):
+        """Test error handling when blueprint retrieval fails."""
+        mock_blueprint_error = {"error": "Blueprint not found"}
+
+        with patch("app.api.blueprints.get_blueprint", return_value=mock_blueprint_error):
+            result = await create_automation_from_blueprint(
+                "nonexistent", inputs={"motion_entity": "binary_sensor.motion"}, domain="automation"
+            )
+
+            assert isinstance(result, dict)
+            assert "error" in result
+            assert result["error"] == "Blueprint not found"
+
+    @pytest.mark.asyncio
+    async def test_create_automation_from_blueprint_no_domain(self):
+        """Test automation creation without domain, extracting from blueprint."""
+        mock_blueprint = {
+            "path": "motion_light",
+            "domain": "automation",
+            "name": "Motion Light",
+            "metadata": {"input": {}},
+        }
+
+        mock_automation_response = {
+            "automation_id": "automation_12345",
+            "status": "created",
+        }
+
+        with (
+            patch("app.api.blueprints.get_blueprint", return_value=mock_blueprint),
+            patch("app.api.blueprints.create_automation", return_value=mock_automation_response),
+        ):
+            result = await create_automation_from_blueprint(
+                "motion_light", inputs={"motion_entity": "binary_sensor.motion"}
+            )
+
+            assert isinstance(result, dict)
+            assert result["automation_id"] == "automation_12345"
+
+    @pytest.mark.asyncio
+    async def test_create_automation_from_blueprint_auto_generate_id(self):
+        """Test that automation_id is auto-generated if not provided."""
+        mock_blueprint = {
+            "path": "motion_light",
+            "domain": "automation",
+            "name": "Motion Light",
+            "metadata": {"input": {}},
+        }
+
+        mock_automation_response = {
+            "automation_id": "automation_abcdef12",
+            "status": "created",
+        }
+
+        with (
+            patch("app.api.blueprints.get_blueprint", return_value=mock_blueprint),
+            patch("app.api.blueprints.create_automation", return_value=mock_automation_response),
+        ):
+            result = await create_automation_from_blueprint(
+                "motion_light",
+                inputs={"motion_entity": "binary_sensor.motion"},
+                domain="automation",
+            )
+
+            assert isinstance(result, dict)
+            assert "automation_id" in result
+
+    @pytest.mark.asyncio
+    async def test_create_automation_from_blueprint_automation_error(self):
+        """Test error handling when automation creation fails."""
+        mock_blueprint = {
+            "path": "motion_light",
+            "domain": "automation",
+            "name": "Motion Light",
+            "metadata": {"input": {}},
+        }
+
+        mock_automation_error = {"error": "Invalid automation config"}
+
+        with (
+            patch("app.api.blueprints.get_blueprint", return_value=mock_blueprint),
+            patch("app.api.blueprints.create_automation", return_value=mock_automation_error),
+        ):
+            result = await create_automation_from_blueprint(
+                "motion_light",
+                inputs={"motion_entity": "binary_sensor.motion"},
+                domain="automation",
+            )
+
+            assert isinstance(result, dict)
+            assert "error" in result


### PR DESCRIPTION
## 📋 Overview
This PR implements Phase 4.4 by adding Blueprints Management tools to the hass-mcp project. Blueprints are reusable automation templates.

## 🎯 Changes

### New API Module Created
- **`app/api/blueprints.py`** with:
  - `list_blueprints()` - Get list of available blueprints, optionally filtered by domain
  - `get_blueprint()` - Get blueprint definition and metadata
  - `import_blueprint()` - Import blueprint from URL
  - `create_automation_from_blueprint()` - Create automation from blueprint with specified inputs
  - Uses `BaseAPI` pattern from Phase 2.1
  - Uses `create_automation` from `app.api.automations`
  - Proper error handling with `handle_api_errors` decorator
  - Handles blueprint metadata and inputs
  - URL encoding for blueprint imports

### New Tools Module Created
- **`app/tools/blueprints.py`** with MCP tool wrappers:
  - `list_blueprints_tool()` - MCP tool for listing blueprints
  - `get_blueprint_tool()` - MCP tool for getting blueprint definition
  - `import_blueprint_tool()` - MCP tool for importing blueprints from URL
  - `create_automation_from_blueprint_tool()` - MCP tool for creating automations from blueprints

### Updated server.py
- Imported blueprints tools module
- Registered blueprints tools with MCP instance
- Added re-exports for backward compatibility
- Removed old tool definitions (moved to `app/tools/blueprints.py`)
- Removed unused imports from `app.hass` (`get_blueprints`, `get_blueprint_definition`, `import_blueprint_from_url`, `create_automation_from_blueprint`)

### Updated tools/__init__.py
- Added blueprints module to `__all__` list

### Testing
- Created `tests/unit/test_api_blueprints.py` with **17 comprehensive tests**:
  - **TestListBlueprints**: 4 tests (success all, filtered by domain, empty result, HTTP error)
  - **TestGetBlueprint**: 4 tests (success with domain, success with path, error no domain, HTTP error)
  - **TestImportBlueprint**: 3 tests (success, URL encoding, HTTP error)
  - **TestCreateAutomationFromBlueprint**: 6 tests (success, with automation_id, blueprint error, no domain, auto generate id, automation error)
- All **269 tests passing**
- **100% coverage** for `app/api/blueprints.py`
- **63% overall coverage** (above 40% gate)
- All linting checks passing

## ✅ Checklist
- [x] API module created with all 4 functions
- [x] Tools module created with all 4 MCP tool wrappers
- [x] Tools registered in `server.py`
- [x] Comprehensive tests added (17 tests)
- [x] All tests passing (269 tests)
- [x] Coverage meets gate (63% overall, 100% for blueprints API)
- [x] Linting checks passing
- [x] Unused imports removed from `app.hass`
- [x] Re-exports added for backward compatibility

## 🔗 Related To
- **Epic**: #28
- **Issue**: #44
- **Depends on**: Phase 3 complete, #41, #42, #43

## 📝 Notes
- Blueprints use domain-specific paths
- Metadata parsing important for input validation
- Import might need network access (tested carefully)
- YAML substitution handled by Home Assistant
- All functions use existing API modules from Phase 2 and 3

Closes #44