### PR TITLE
Fix AttributeError in logbook search when fields are None

### DIFF
--- a/app/api/logbook.py
+++ b/app/api/logbook.py
@@ -153,9 +153,10 @@ async def search_logbook(query: str, hours: int = 24) -> list[dict[str, Any]]:
 
     for entry in entries:
         # Search in entity_id, name, message, etc.
-        entry_entity_id = entry.get("entity_id", "").lower()
-        entry_name = entry.get("name", "").lower()
-        entry_message = entry.get("message", "").lower()
+        # Handle None values: entry.get() only returns default if key missing, not if value is None
+        entry_entity_id = (entry.get("entity_id") or "").lower()
+        entry_name = (entry.get("name") or "").lower()
+        entry_message = (entry.get("message") or "").lower()
 
         if (
             query_lower in entry_entity_id

--- a/tests/unit/test_api_logbook.py
+++ b/tests/unit/test_api_logbook.py
@@ -304,3 +304,36 @@ class TestSearchLogbook:
             assert isinstance(result, list)
             assert len(result) == 1
             assert "error" in result[0]["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_search_logbook_with_none_values(self):
+        """Test that search handles None values in entity_id, name, or message."""
+        mock_entries = [
+            {
+                "when": "2025-03-15T10:30:00Z",
+                "name": None,
+                "entity_id": None,
+                "message": "turned on",
+            },
+            {
+                "when": "2025-03-15T10:25:00Z",
+                "name": "Kitchen Light",
+                "entity_id": "light.kitchen",
+                "message": None,
+            },
+            {
+                "when": "2025-03-15T10:20:00Z",
+                "name": None,
+                "entity_id": "sensor.temperature",
+                "message": None,
+            },
+        ]
+
+        with patch("app.api.logbook.get_logbook", return_value=mock_entries):
+            # Should not raise AttributeError: 'NoneType' object has no attribute 'lower'
+            result = await search_logbook("light", hours=24)
+
+            assert isinstance(result, list)
+            # Should find matches despite None values
+            assert len(result) == 1
+            assert result[0]["entity_id"] == "light.kitchen"


### PR DESCRIPTION
## Problem

The `search_logbook()` function was crashing with the error:
```
'NoneType' object has no attribute 'lower'
```

This occurred when logbook entries contained `null` values for fields like `entity_id`, `name`, or `message`. The error was observed in the log:
```
2025-11-03 17:59:33,910 - httpx - INFO - HTTP Request: GET http://10.0.0.32:8123/api/logbook/2025-11-02T17:59:32 "HTTP/1.1 200 OK"
{"jsonrpc":"2.0","id":8,"result":{"content":[{"type":"text","text":"{\n  \"error\": \"Unexpected error: 'NoneType' object has no attribute 'lower'\"\n}"}],"structuredContent":{"result":[{"error":"Unexpected error: 'NoneType' object has no attribute 'lower'"}]},"isError":false}}
```

## Root Cause

The issue was in the `search_logbook()` function in `app/api/logbook.py` (lines 156-158). The code was using:
```python
entry_entity_id = entry.get("entity_id", "").lower()
entry_name = entry.get("name", "").lower()
entry_message = entry.get("message", "").lower()
```

The problem is that Python's `.get()` method with a default value (`""`) only returns the default **when the key is missing**. If the key exists but the value is `None` (which is common in Home Assistant logbook entries), `.get()` returns `None`, not the default value. Then calling `.lower()` on `None` raises the `AttributeError`.

## Solution

Changed the code to handle `None` values explicitly:
```python
entry_entity_id = (entry.get("entity_id") or "").lower()
entry_name = (entry.get("name") or "").lower()
entry_message = (entry.get("message") or "").lower()
```

Using `or ""` ensures that if `entry.get("field")` returns `None`, it will be replaced with an empty string before calling `.lower()`. This handles both:
- Missing keys (returns `None` from `.get()`, then `""` from `or ""`)
- Keys with `None` values (returns `None` from `.get()`, then `""` from `or ""`)

## Changes Made

1. **`app/api/logbook.py`**: Updated `search_logbook()` function to handle `None` values using `or ""` pattern
2. **`tests/unit/test_api_logbook.py`**: Added `test_search_logbook_with_none_values()` test case to verify the fix handles `None` values correctly

## Testing

- ✅ Added unit test that verifies `None` values in `entity_id`, `name`, and `message` fields are handled correctly
- ✅ All existing tests pass
- ✅ Pre-commit hooks passed (ruff, bandit, etc.)

## Impact

- **Before**: `search_logbook()` would crash when encountering logbook entries with `null` values
- **After**: `search_logbook()` gracefully handles `null` values by treating them as empty strings

This fix ensures the logbook search functionality is robust and handles all edge cases that Home Assistant's API may return.