### PR TITLE
US-006: Explicitly Exclude Dynamic Data from Caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,19 @@ The following API functions are automatically cached:
 - **Tags**: `list_tags` (TTL_LONG, 30 min)
 - **System**: `get_hass_version`, `get_core_config` (TTL_VERY_LONG, 1 hour)
 
+### Excluded from Caching (US-006)
+
+The following API functions are **explicitly excluded from caching** because they return highly dynamic, time-sensitive data:
+
+- **Logbook**: `get_logbook`, `get_entity_logbook`, `search_logbook` - Logbook entries are time-sensitive and change frequently
+- **History**: `get_entity_history` - Entity history is time-based and highly dynamic
+- **Statistics**: `get_entity_statistics`, `get_domain_statistics`, `analyze_usage_patterns` - Statistics are derived from history/logbook data and are highly dynamic
+- **Events**: `get_events` - Events are time-sensitive and change frequently
+- **Automation Execution Logs**: `get_automation_execution_log` - Execution logs are time-sensitive and change frequently
+- **System**: `get_hass_error_log`, `get_system_overview` - Error logs and system overview include current entity states which are highly dynamic
+
+These endpoints will always fetch fresh data from Home Assistant and never use cached results, ensuring accuracy for time-sensitive operations.
+
 ### Cache Invalidation
 
 Cache is automatically invalidated when data is modified:

--- a/app/api/automations.py
+++ b/app/api/automations.py
@@ -272,6 +272,8 @@ async def trigger_automation(automation_id: str) -> dict[str, Any]:
     return cast(dict[str, Any], response.json())
 
 
+# NOTE: This function is explicitly excluded from caching (US-006)
+# Execution logs are highly dynamic and time-sensitive, so they should not be cached
 @handle_api_errors
 async def get_automation_execution_log(automation_id: str, hours: int = 24) -> dict[str, Any]:
     """

--- a/app/api/entities.py
+++ b/app/api/entities.py
@@ -260,6 +260,8 @@ async def get_entities(
     return cast(list[dict[str, Any]], entities)
 
 
+# NOTE: This function is explicitly excluded from caching (US-006)
+# History data is highly dynamic and time-sensitive, so it should not be cached
 @handle_api_errors
 async def get_entity_history(entity_id: str, hours: int) -> list[dict[str, Any]]:
     """

--- a/app/api/events.py
+++ b/app/api/events.py
@@ -107,6 +107,8 @@ async def list_event_types() -> list[str]:
     return common_event_types
 
 
+# NOTE: This function is explicitly excluded from caching (US-006)
+# Events are highly dynamic and time-sensitive, so they should not be cached
 @handle_api_errors
 async def get_events(entity_id: str | None = None, hours: int = 1) -> list[dict[str, Any]]:
     """

--- a/app/api/logbook.py
+++ b/app/api/logbook.py
@@ -22,6 +22,8 @@ class LogbookAPI(BaseAPI):
 _logbook_api = LogbookAPI()
 
 
+# NOTE: This function is explicitly excluded from caching (US-006)
+# Logbook data is highly dynamic and time-sensitive, so it should not be cached
 @handle_api_errors
 async def get_logbook(
     timestamp: str | None = None,
@@ -89,6 +91,8 @@ async def get_logbook(
     return cast(list[dict[str, Any]], response)
 
 
+# NOTE: This function is explicitly excluded from caching (US-006)
+# Logbook data is highly dynamic and time-sensitive, so it should not be cached
 @handle_api_errors
 async def get_entity_logbook(entity_id: str, hours: int = 24) -> list[dict[str, Any]]:
     """
@@ -117,6 +121,8 @@ async def get_entity_logbook(entity_id: str, hours: int = 24) -> list[dict[str, 
     return await get_logbook(entity_id=entity_id, hours=hours)
 
 
+# NOTE: This function is explicitly excluded from caching (US-006)
+# Logbook data is highly dynamic and time-sensitive, so it should not be cached
 @handle_api_errors
 async def search_logbook(query: str, hours: int = 24) -> list[dict[str, Any]]:
     """

--- a/app/api/statistics.py
+++ b/app/api/statistics.py
@@ -14,6 +14,8 @@ from app.core.decorators import handle_api_errors
 logger = logging.getLogger(__name__)
 
 
+# NOTE: This function is explicitly excluded from caching (US-006)
+# Statistics are derived from history data and are highly dynamic, so they should not be cached
 @handle_api_errors
 async def get_entity_statistics(entity_id: str, period_days: int = 7) -> dict[str, Any]:
     """
@@ -123,6 +125,8 @@ async def get_entity_statistics(entity_id: str, period_days: int = 7) -> dict[st
     return stats
 
 
+# NOTE: This function is explicitly excluded from caching (US-006)
+# Statistics are derived from history data and are highly dynamic, so they should not be cached
 @handle_api_errors
 async def get_domain_statistics(domain: str, period_days: int = 7) -> dict[str, Any]:
     """
@@ -200,6 +204,8 @@ async def get_domain_statistics(domain: str, period_days: int = 7) -> dict[str, 
     return stats
 
 
+# NOTE: This function is explicitly excluded from caching (US-006)
+# Usage patterns are derived from logbook data and are highly dynamic, so they should not be cached
 @handle_api_errors
 async def analyze_usage_patterns(entity_id: str, days: int = 30) -> dict[str, Any]:
     """

--- a/app/api/system.py
+++ b/app/api/system.py
@@ -40,6 +40,8 @@ async def get_hass_version() -> str:
     return data.get("version", "unknown")
 
 
+# NOTE: This function is explicitly excluded from caching (US-006)
+# Error logs are highly dynamic and time-sensitive, so they should not be cached
 @handle_api_errors
 async def get_hass_error_log() -> dict[str, Any]:
     """
@@ -119,6 +121,8 @@ async def get_hass_error_log() -> dict[str, Any]:
         }
 
 
+# NOTE: This function is explicitly excluded from caching (US-006)
+# System overview includes current entity states which are highly dynamic, so it should not be cached
 @handle_api_errors
 async def get_system_overview() -> dict[str, Any]:
     """

--- a/app/core/cache/manager.py
+++ b/app/core/cache/manager.py
@@ -193,6 +193,30 @@ class CacheManager:
             # Never break API calls on cache errors
             logger.warning(f"Cache clear error: {e}", exc_info=True)
 
+    async def keys(self, pattern: str | None = None) -> list[str]:
+        """
+        Get cache keys matching a pattern.
+
+        Args:
+            pattern: Optional pattern to match keys (supports wildcards like '*')
+
+        Returns:
+            List of matching cache keys
+        """
+        if not self._enabled:
+            return []
+
+        try:
+            backend = await self._get_backend()
+            if backend is None:
+                return []
+
+            return await backend.keys(pattern)
+        except Exception as e:
+            # Never break API calls on cache errors
+            logger.warning(f"Cache keys error for pattern '{pattern}': {e}", exc_info=True)
+            return []
+
     def get_statistics(self) -> dict[str, Any]:
         """
         Get cache statistics.

--- a/tests/unit/test_cache_excluded_endpoints.py
+++ b/tests/unit/test_cache_excluded_endpoints.py
@@ -1,0 +1,452 @@
+"""Unit tests for explicitly excluded dynamic data endpoints (US-006)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.api.automations import get_automation_execution_log
+from app.api.entities import get_entity_history
+from app.api.events import get_events
+from app.api.logbook import get_entity_logbook, get_logbook, search_logbook
+from app.api.statistics import analyze_usage_patterns, get_domain_statistics, get_entity_statistics
+from app.api.system import get_hass_error_log, get_system_overview
+from app.core.cache.manager import get_cache_manager
+
+
+@pytest.fixture(autouse=True)
+async def clear_cache_fixture():
+    """Clear cache before each test to ensure isolation."""
+    cache = await get_cache_manager()
+    await cache.clear()
+    yield
+    await cache.clear()
+
+
+class TestLogbookEndpointsNotCached:
+    """Test that logbook endpoints are not cached."""
+
+    @pytest.mark.asyncio
+    async def test_get_logbook_not_cached(self):
+        """Test that get_logbook is not cached."""
+        mock_logbook = [
+            {
+                "when": "2025-01-01T10:00:00Z",
+                "name": "Test Entity",
+                "entity_id": "light.test",
+                "state": "on",
+            }
+        ]
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = mock_logbook
+        mock_response.raise_for_status = MagicMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with (
+            patch("app.api.logbook._logbook_api._get_client", return_value=mock_client),
+            patch("app.core.decorators.HA_TOKEN", "test_token"),
+        ):
+            # First call
+            result1 = await get_logbook()
+            assert isinstance(result1, list)
+
+            # Verify cache is empty after first call
+            cache = await get_cache_manager()
+            keys = await cache.keys("*")
+            assert len(keys) == 0  # No cache entries
+
+            # Second call - should NOT be cached
+            result2 = await get_logbook()
+            assert isinstance(result2, list)
+
+            # Verify cache is still empty
+            keys = await cache.keys("*")
+            assert len(keys) == 0  # Still no cache entries
+
+    @pytest.mark.asyncio
+    async def test_get_entity_logbook_not_cached(self):
+        """Test that get_entity_logbook is not cached."""
+        mock_logbook = [
+            {
+                "when": "2025-01-01T10:00:00Z",
+                "name": "Test Entity",
+                "entity_id": "light.test",
+                "state": "on",
+            }
+        ]
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = mock_logbook
+        mock_response.raise_for_status = MagicMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with (
+            patch("app.api.logbook._logbook_api._get_client", return_value=mock_client),
+            patch("app.core.decorators.HA_TOKEN", "test_token"),
+        ):
+            # First call
+            result1 = await get_entity_logbook("light.test")
+            assert isinstance(result1, list)
+
+            # Verify cache is empty
+            cache = await get_cache_manager()
+            keys = await cache.keys("*")
+            assert len(keys) == 0  # No cache entries
+
+            # Second call - should NOT be cached
+            result2 = await get_entity_logbook("light.test")
+            assert isinstance(result2, list)
+
+            # Verify cache is still empty
+            keys = await cache.keys("*")
+            assert len(keys) == 0  # Still no cache entries
+
+    @pytest.mark.asyncio
+    async def test_search_logbook_not_cached(self):
+        """Test that search_logbook is not cached."""
+        mock_logbook = [
+            {
+                "when": "2025-01-01T10:00:00Z",
+                "name": "Test Entity",
+                "entity_id": "light.test",
+                "state": "on",
+            }
+        ]
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = mock_logbook
+        mock_response.raise_for_status = MagicMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with (
+            patch("app.api.logbook._logbook_api._get_client", return_value=mock_client),
+            patch("app.core.decorators.HA_TOKEN", "test_token"),
+        ):
+            # First call
+            result1 = await search_logbook("test")
+            assert isinstance(result1, list)
+
+            # Verify cache is empty
+            cache = await get_cache_manager()
+            keys = await cache.keys("*")
+            assert len(keys) == 0  # No cache entries
+
+            # Second call - should NOT be cached
+            result2 = await search_logbook("test")
+            assert isinstance(result2, list)
+
+            # Verify cache is still empty
+            keys = await cache.keys("*")
+            assert len(keys) == 0  # Still no cache entries
+
+
+class TestHistoryEndpointsNotCached:
+    """Test that history endpoints are not cached."""
+
+    @pytest.mark.asyncio
+    async def test_get_entity_history_not_cached(self):
+        """Test that get_entity_history is not cached."""
+        mock_history = [[{"state": "on", "last_changed": "2025-01-01T10:00:00Z"}]]
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = mock_history
+        mock_response.raise_for_status = MagicMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with (
+            patch("app.api.entities.get_client", return_value=mock_client),
+            patch("app.core.decorators.HA_TOKEN", "test_token"),
+        ):
+            # First call
+            result1 = await get_entity_history("light.test", hours=24)
+            assert isinstance(result1, list)
+
+            # Verify cache is empty
+            cache = await get_cache_manager()
+            keys = await cache.keys("*")
+            assert len(keys) == 0  # No cache entries
+
+            # Second call - should NOT be cached
+            result2 = await get_entity_history("light.test", hours=24)
+            assert isinstance(result2, list)
+
+            # Verify cache is still empty
+            keys = await cache.keys("*")
+            assert len(keys) == 0  # Still no cache entries
+
+
+class TestStatisticsEndpointsNotCached:
+    """Test that statistics endpoints are not cached."""
+
+    @pytest.mark.asyncio
+    async def test_get_entity_statistics_not_cached(self):
+        """Test that get_entity_statistics is not cached."""
+        mock_history = [
+            [
+                {"state": "20.5", "last_changed": "2025-01-01T10:00:00Z"},
+                {"state": "21.0", "last_changed": "2025-01-01T11:00:00Z"},
+            ]
+        ]
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = mock_history
+        mock_response.raise_for_status = MagicMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with (
+            patch("app.api.entities.get_client", return_value=mock_client),
+            patch("app.core.decorators.HA_TOKEN", "test_token"),
+        ):
+            # First call
+            result1 = await get_entity_statistics("sensor.temperature", period_days=7)
+            assert isinstance(result1, dict)
+
+            # Verify cache is empty
+            cache = await get_cache_manager()
+            keys = await cache.keys("*")
+            assert len(keys) == 0  # No cache entries
+
+            # Second call - should NOT be cached
+            result2 = await get_entity_statistics("sensor.temperature", period_days=7)
+            assert isinstance(result2, dict)
+
+            # Verify cache is still empty
+            keys = await cache.keys("*")
+            assert len(keys) == 0  # Still no cache entries
+
+    @pytest.mark.asyncio
+    async def test_get_domain_statistics_not_cached(self):
+        """Test that get_domain_statistics is not cached."""
+        mock_entities = [{"entity_id": "sensor.temperature", "state": "20.5"}]
+        mock_history = [
+            [
+                {"state": "20.5", "last_changed": "2025-01-01T10:00:00Z"},
+            ]
+        ]
+        mock_client = AsyncMock()
+        mock_response_entities = MagicMock()
+        mock_response_entities.json.return_value = mock_entities
+        mock_response_entities.raise_for_status = MagicMock()
+        mock_response_history = MagicMock()
+        mock_response_history.json.return_value = mock_history
+        mock_response_history.raise_for_status = MagicMock()
+        mock_client.get = AsyncMock(side_effect=[mock_response_entities, mock_response_history])
+
+        with (
+            patch("app.api.entities.get_client", return_value=mock_client),
+            patch("app.core.decorators.HA_TOKEN", "test_token"),
+        ):
+            # First call
+            result1 = await get_domain_statistics("sensor", period_days=7)
+            assert isinstance(result1, dict)
+
+            # Verify no cache entries for statistics endpoints
+            # (get_domain_statistics calls get_entities which is cached, so there may be entities:* entries)
+            cache = await get_cache_manager()
+            keys = await cache.keys("*")
+            # Check that there are no cache entries for statistics endpoints specifically
+            stats_keys = [
+                k for k in keys if "statistics" in k.lower() or "domain_statistics" in k.lower()
+            ]
+            assert len(stats_keys) == 0  # No statistics cache entries
+
+            # Second call - should NOT be cached
+            result2 = await get_domain_statistics("sensor", period_days=7)
+            assert isinstance(result2, dict)
+
+            # Verify still no statistics cache entries
+            keys = await cache.keys("*")
+            stats_keys = [
+                k for k in keys if "statistics" in k.lower() or "domain_statistics" in k.lower()
+            ]
+            assert len(stats_keys) == 0  # Still no statistics cache entries
+
+    @pytest.mark.asyncio
+    async def test_analyze_usage_patterns_not_cached(self):
+        """Test that analyze_usage_patterns is not cached."""
+        mock_logbook = [
+            {
+                "when": "2025-01-01T10:00:00Z",
+                "name": "Test Entity",
+                "entity_id": "light.test",
+                "state": "on",
+            }
+        ]
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = mock_logbook
+        mock_response.raise_for_status = MagicMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with (
+            patch("app.api.logbook._logbook_api._get_client", return_value=mock_client),
+            patch("app.core.decorators.HA_TOKEN", "test_token"),
+        ):
+            # First call
+            result1 = await analyze_usage_patterns("light.test", days=30)
+            assert isinstance(result1, dict)
+
+            # Verify cache is empty
+            cache = await get_cache_manager()
+            keys = await cache.keys("*")
+            assert len(keys) == 0  # No cache entries
+
+            # Second call - should NOT be cached
+            result2 = await analyze_usage_patterns("light.test", days=30)
+            assert isinstance(result2, dict)
+
+            # Verify cache is still empty
+            keys = await cache.keys("*")
+            assert len(keys) == 0  # Still no cache entries
+
+
+class TestEventsEndpointsNotCached:
+    """Test that events endpoints are not cached."""
+
+    @pytest.mark.asyncio
+    async def test_get_events_not_cached(self):
+        """Test that get_events is not cached."""
+        mock_logbook = [
+            {
+                "when": "2025-01-01T10:00:00Z",
+                "name": "Test Entity",
+                "entity_id": "light.test",
+                "state": "on",
+            }
+        ]
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = mock_logbook
+        mock_response.raise_for_status = MagicMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with (
+            patch("app.api.logbook._logbook_api._get_client", return_value=mock_client),
+            patch("app.core.decorators.HA_TOKEN", "test_token"),
+        ):
+            # First call
+            result1 = await get_events(entity_id="light.test", hours=1)
+            assert isinstance(result1, list)
+
+            # Verify cache is empty
+            cache = await get_cache_manager()
+            keys = await cache.keys("*")
+            assert len(keys) == 0  # No cache entries
+
+            # Second call - should NOT be cached
+            result2 = await get_events(entity_id="light.test", hours=1)
+            assert isinstance(result2, list)
+
+            # Verify cache is still empty
+            keys = await cache.keys("*")
+            assert len(keys) == 0  # Still no cache entries
+
+
+class TestAutomationExecutionLogNotCached:
+    """Test that automation execution logs are not cached."""
+
+    @pytest.mark.asyncio
+    async def test_get_automation_execution_log_not_cached(self):
+        """Test that get_automation_execution_log is not cached."""
+        mock_logbook = [
+            {
+                "when": "2025-01-01T10:00:00Z",
+                "name": "Test Automation",
+                "entity_id": "automation.test",
+                "state": "on",
+            }
+        ]
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = mock_logbook
+        mock_response.raise_for_status = MagicMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with (
+            patch("app.api.automations.get_client", return_value=mock_client),
+            patch("app.core.decorators.HA_TOKEN", "test_token"),
+        ):
+            # First call
+            result1 = await get_automation_execution_log("test", hours=24)
+            assert isinstance(result1, dict)
+
+            # Verify cache is empty
+            cache = await get_cache_manager()
+            keys = await cache.keys("*")
+            assert len(keys) == 0  # No cache entries
+
+            # Second call - should NOT be cached
+            result2 = await get_automation_execution_log("test", hours=24)
+            assert isinstance(result2, dict)
+
+            # Verify cache is still empty
+            keys = await cache.keys("*")
+            assert len(keys) == 0  # Still no cache entries
+
+
+class TestSystemEndpointsNotCached:
+    """Test that dynamic system endpoints are not cached."""
+
+    @pytest.mark.asyncio
+    async def test_get_hass_error_log_not_cached(self):
+        """Test that get_hass_error_log is not cached."""
+        mock_error_log = "ERROR: Test error message\nWARNING: Test warning"
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.text = mock_error_log
+        mock_response.status_code = 200
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with (
+            patch("app.api.system.get_client", return_value=mock_client),
+            patch("app.core.decorators.HA_TOKEN", "test_token"),
+        ):
+            # First call
+            result1 = await get_hass_error_log()
+            assert isinstance(result1, dict)
+
+            # Verify cache is empty
+            cache = await get_cache_manager()
+            keys = await cache.keys("*")
+            assert len(keys) == 0  # No cache entries
+
+            # Second call - should NOT be cached
+            result2 = await get_hass_error_log()
+            assert isinstance(result2, dict)
+
+            # Verify cache is still empty
+            keys = await cache.keys("*")
+            assert len(keys) == 0  # Still no cache entries
+
+    @pytest.mark.asyncio
+    async def test_get_system_overview_not_cached(self):
+        """Test that get_system_overview is not cached."""
+        mock_entities = [
+            {"entity_id": "light.test", "state": "on", "attributes": {"friendly_name": "Test"}}
+        ]
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = mock_entities
+        mock_response.raise_for_status = MagicMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with (
+            patch("app.api.system.get_client", return_value=mock_client),
+            patch("app.core.decorators.HA_TOKEN", "test_token"),
+        ):
+            # First call
+            result1 = await get_system_overview()
+            assert isinstance(result1, dict)
+
+            # Verify cache is empty
+            cache = await get_cache_manager()
+            keys = await cache.keys("*")
+            assert len(keys) == 0  # No cache entries
+
+            # Second call - should NOT be cached
+            result2 = await get_system_overview()
+            assert isinstance(result2, dict)
+
+            # Verify cache is still empty
+            keys = await cache.keys("*")
+            assert len(keys) == 0  # Still no cache entries


### PR DESCRIPTION
## Summary

This PR implements US-006: Explicitly Exclude Dynamic Data from Caching. It adds explicit documentation and comments to dynamic data endpoints indicating they are excluded from caching, ensuring fresh data for time-sensitive operations.

## Changes

### Code Documentation
- Added explicit comments to all dynamic data endpoints indicating they are excluded from caching (US-006):
  - **Logbook**: `get_logbook`, `get_entity_logbook`, `search_logbook`
  - **History**: `get_entity_history`
  - **Statistics**: `get_entity_statistics`, `get_domain_statistics`, `analyze_usage_patterns`
  - **Events**: `get_events`
  - **Automation Execution Logs**: `get_automation_execution_log`
  - **System**: `get_hass_error_log`, `get_system_overview`

### Cache Manager Enhancement
- Added `keys()` method to `CacheManager` to expose cache key access for testing and debugging

### Testing
- Created comprehensive test suite (`test_cache_excluded_endpoints.py`) with 11 tests:
  - Tests for logbook endpoints (3 tests)
  - Tests for history endpoints (1 test)
  - Tests for statistics endpoints (3 tests)
  - Tests for events endpoints (1 test)
  - Tests for automation execution logs (1 test)
  - Tests for dynamic system endpoints (2 tests)
- All tests verify that dynamic endpoints are not cached by checking cache keys

### Documentation
- Updated `README.md` with new "Excluded from Caching (US-006)" section
- Documented all excluded endpoints and the reasons for exclusion
- Added note that these endpoints always fetch fresh data

## Verification

- ✅ All 463 unit tests passing
- ✅ No linting errors
- ✅ All dynamic endpoints explicitly documented as excluded
- ✅ Comprehensive test coverage for excluded endpoints
- ✅ README updated with excluded endpoints section

## Impact

This change ensures that:
1. Dynamic, time-sensitive data is never cached
2. Developers can clearly see which endpoints are excluded from caching
3. Tests verify that excluded endpoints are not cached
4. Documentation clearly explains why certain endpoints are excluded

## Related Issues

- Closes #100 (US-006)