### PR TITLE
feat: improve service tool reliability with better errors, descriptions, and new tools

### DIFF
--- a/app/api/services.py
+++ b/app/api/services.py
@@ -40,10 +40,12 @@ async def call_service(
     Args:
         domain: The service domain (e.g., 'light', 'switch', 'automation')
         service: The service name (e.g., 'turn_on', 'turn_off', 'toggle')
-        data: Optional dictionary of service data/parameters
+        data: Optional dictionary of service data/parameters. Pass an empty
+            dict {} or None for services that accept no parameters
+            (reload, restart, refresh, etc.).
         return_response: If True, request response data from services that support it.
             Some services return structured data (e.g., weather.get_forecasts).
-            If the service doesn't support responses, this may cause an error.
+            If the service doesn't support responses, this may cause a 400 error.
 
     Returns:
         Response from the service call. Without return_response, usually returns
@@ -62,21 +64,23 @@ async def call_service(
         }
 
     Examples:
-        # Turn on a light
+        # Turn on a light (service that accepts data)
         await call_service("light", "turn_on", {"entity_id": "light.living_room"})
 
         # Get weather forecast (with response data)
         await call_service("weather", "get_forecasts",
             {"entity_id": "weather.home", "type": "daily"}, return_response=True)
 
-        # Toggle a switch
-        await call_service("switch", "toggle", {"entity_id": "switch.garden_lights"})
+        # Reload scenes (service that accepts NO data)
+        await call_service("scene", "reload", {})
 
     Note:
-        Services are used by many other domains and are generic and reusable patterns.
-        Common domains include light, switch, fan, cover, climate, etc.
-        Service data varies by domain and service type.
+        Services like scene.reload, automation.reload, homeassistant.restart,
+        homeassistant.reload_core_config accept NO service data. Passing any
+        data to them will cause a 400 Bad Request error from Home Assistant.
         Use return_response=True only for services that support response data.
+        Passing return_response=True on a service that doesn't support it
+        will also cause a 400 error.
 
     Best Practices:
         - Check service availability before calling
@@ -96,3 +100,24 @@ async def call_service(
     response = await client.post(url, headers=get_ha_headers(), json=data)
     response.raise_for_status()
     return cast(dict[str, Any], response.json())
+
+
+async def get_service_definitions() -> list[dict[str, Any]]:
+    """Fetch all available Home Assistant service definitions with their field schemas.
+
+    Calls GET /api/services which returns service definitions organized by domain.
+    Each service includes its name, description, and field schema.
+
+    Returns:
+        List of service definition dicts, each containing:
+            domain (str): The service domain
+            services (list[dict]): Available services with name, description, fields
+
+    Example:
+        await get_service_definitions()
+    """
+    client = await get_client()
+    url = f"{HA_URL}/api/services"
+    response = await client.get(url, headers=get_ha_headers())
+    response.raise_for_status()
+    return cast(list[dict[str, Any]], response.json())

--- a/app/core/decorators.py
+++ b/app/core/decorators.py
@@ -73,8 +73,14 @@ def handle_api_errors(func: F) -> F:
                 f"Timeout error: Home Assistant at {HA_URL} did not respond in time"
             )
         except httpx.HTTPStatusError as e:
+            body = ""
+            try:
+                body = f" - {e.response.json().get('message', '')}"
+            except Exception:
+                if e.response.text:
+                    body = f" - {e.response.text[:500]}"
             return format_error(
-                f"HTTP error: {e.response.status_code} - {e.response.reason_phrase}"
+                f"HTTP error: {e.response.status_code} {e.response.reason_phrase}{body}"
             )
         except httpx.RequestError as e:
             return format_error(f"Error connecting to Home Assistant: {str(e)}")

--- a/app/server.py
+++ b/app/server.py
@@ -119,6 +119,8 @@ mcp.tool()(async_handler("restart_ha")(system.restart_ha))
 
 # Register service tools with MCP instance
 mcp.tool()(async_handler("call_service")(services.call_service_tool))
+mcp.tool()(async_handler("call_service_simple")(services.call_service_simple_tool))
+mcp.tool()(async_handler("list_services")(services.list_services_tool))
 
 # Register template tools with MCP instance
 mcp.tool()(async_handler("test_template")(templates.test_template_tool))

--- a/app/tools/services.py
+++ b/app/tools/services.py
@@ -7,7 +7,7 @@ These tools are thin wrappers around the services API layer.
 import logging
 from typing import Any
 
-from app.api.services import call_service
+from app.api.services import call_service, get_service_definitions
 
 logger = logging.getLogger(__name__)
 
@@ -21,12 +21,21 @@ async def call_service_tool(
     """
     Call any Home Assistant service (low-level API access).
 
+    Use this for services that accept parameters (data). For services like
+    reload, restart, or refresh that accept NO data, use call_service_simple
+    instead to avoid 400 errors from HA.
+
     Args:
         domain: The domain of the service (e.g., 'light', 'switch', 'automation')
         service: The service to call (e.g., 'turn_on', 'turn_off', 'toggle')
-        data: Optional data to pass to the service (e.g., {'entity_id': 'light.living_room'})
+        data: Service parameters as a dict. Omit or set to null for services
+            that don't accept data (reload, restart, refresh, etc.).
+            Example: {'entity_id': 'light.living_room', 'brightness': 128}
+            ⚠ Services like scene.reload, automation.reload, homeassistant.restart
+            accept NO data — passing any will cause a 400 error.
         return_response: If True, request response data from services that support it.
-            Use this for services that return structured data (e.g., weather.get_forecasts).
+            Use only for services known to return data (e.g., weather.get_forecasts).
+            Using this on services that don't support responses will cause a 400 error.
 
     Returns:
         The response from Home Assistant. Without return_response: usually empty for
@@ -34,14 +43,81 @@ async def call_service_tool(
 
     Examples:
         domain='light', service='turn_on', data={'entity_id': 'light.x', 'brightness': 255}
-        domain='automation', service='reload'
         domain='weather', service='get_forecasts', data={'entity_id': 'weather.home', 'type': 'daily'}, return_response=True
 
-    Best Practices:
-        - Use domain and service to identify the service to call
-        - Pass service data in the data parameter
-        - Check response for errors or status
-        - Use return_response=True for services that return data (like weather forecasts)
+    Services that accept NO data (use call_service_simple instead):
+        - domain='scene', service='reload'
+        - domain='automation', service='reload'
+        - domain='homeassistant', service='restart'
+        - domain='homeassistant', service='reload_core_config'
+        - domain='script', service='reload'
     """
     logger.info(f"Calling Home Assistant service: {domain}.{service} with data: {data}")
     return await call_service(domain, service, data or {}, return_response=return_response)
+
+
+async def list_services_tool(
+    domain: str | None = None,
+) -> list[dict[str, Any]]:
+    """
+    List available Home Assistant services with their parameter schemas.
+
+    Use this to discover what services are available and what data fields
+    they accept before calling them. Each service definition includes
+    field names, types, and whether they are required.
+
+    Args:
+        domain: Optional domain to filter by (e.g., 'light', 'scene', 'automation').
+            If omitted, returns all services across all domains.
+
+    Returns:
+        List of service definitions. Each entry contains:
+            domain (str): The service domain
+            services (list): Available services with name, description, fields
+
+    Examples:
+        domain='scene' -> returns all scene services with their field schemas
+        domain='light' -> returns light services like turn_on, turn_off with field schemas
+        (no filter)    -> returns all services across all domains
+
+    Best Practices:
+        - Call this first when you're unsure what data a service needs
+        - Use the 'fields' in each service definition to build the data dict
+        - Services with empty 'fields' accept no data (reload, restart, etc.)
+    """
+    logger.info(f"Listing services for domain: {domain or 'all'}")
+    all_services = await get_service_definitions()
+    if domain:
+        domain_lower = domain.lower()
+        return [s for s in all_services if s.get("domain") == domain_lower]
+    return all_services
+
+
+async def call_service_simple_tool(
+    domain: str,
+    service: str,
+) -> dict[str, Any]:
+    """
+    Call a Home Assistant service that accepts NO data parameters.
+
+    Use this for reload, restart, refresh operations that don't accept
+    any service data. Passing data to these services via call_service
+    would result in a 400 Bad Request error.
+
+    Args:
+        domain: The domain of the service (e.g., 'scene', 'automation', 'homeassistant')
+        service: The service to call (e.g., 'reload', 'restart', 'refresh')
+
+    Returns:
+        The response from Home Assistant (typically an empty list for successful calls).
+
+    Examples:
+        domain='scene', service='reload'
+        domain='automation', service='reload'
+        domain='homeassistant', service='restart'
+        domain='homeassistant', service='reload_core_config'
+        domain='script', service='reload'
+        domain='group', service='reload'
+    """
+    logger.info(f"Calling simple service (no data): {domain}.{service}")
+    return await call_service(domain, service, data={})


### PR DESCRIPTION
## Summary

This PR addresses a recurring issue where LLMs using the `call_service` tool get 400 errors from Home Assistant because they pass data to services that don't accept it (e.g. `scene.reload`, `automation.reload`, `homeassistant.restart`). The fix spans 4 complementary phases.

## Changes

### Phase 1 — Better Error Messages (`app/core/decorators.py`)

Previously, HTTP errors returned only the status code and reason phrase: `"HTTP error: 400 - Bad Request"`. Now the HA response body is included:

```
HTTP error: 400 Bad Request - Service scene.reload does not accept data
```

This lets the LLM understand *why* the call failed and self-correct.

### Phase 2 — Better Tool Descriptions (`app/tools/services.py`, `app/api/services.py`)

- `data` parameter warns that passing data to no-data services causes 400 errors
- `return_response` warns that using it on unsupporting services causes 400 errors
- Added explicit list of data-free services in the docstring
- Synced improvements to the API layer

### Phase 3 — Service Definitions Tool (`app/api/services.py`, `app/tools/services.py`, `app/server.py`)

New **`list_services`** MCP tool that calls `GET /api/services` and returns field schemas. LLMs can introspect what data a service accepts before calling it:

```
list_services(domain="scene")
# -> [{domain: "scene", services: [{service: "reload", fields: {}}, ...]}]
```

Services with empty `fields` accept no data.

### Phase 4 — Split Tool for Data-Free Services (`app/tools/services.py`, `app/server.py`)

New **`call_service_simple`** MCP tool with **no `data` parameter** in its schema, making it schema-impossible to pass data to a service that doesn't need it:

```
call_service_simple(domain="scene", service="reload")
```

## Files Changed

| File | Lines | Change |
|------|-------|--------|
| `app/core/decorators.py` | +7/-1 | Include HA response body in error messages |
| `app/api/services.py` | +33/-8 | Improved docstrings + new `get_service_definitions` API function |
| `app/tools/services.py` | +85/-9 | Improved docstrings + `list_services_tool` + `call_service_simple_tool` |
| `app/server.py` | +2/-0 | Register new tools with MCP |

## Testing

- `make format` - passed
- `make lint` - passed
- `make test` - passed (1023 tests)
- `make type-check` - only pre-existing errors in unrelated files (non-blocking per AGENTS.md)
